### PR TITLE
Update ProxySQL chart version to 1.0.0 in Chart.yaml

### DIFF
--- a/charts/proxysql/Chart.yaml
+++ b/charts/proxysql/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 appVersion: "2.5.5"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.14.3
+version: 1.0.0
 home: https://www.proxysql.com/
 sources:
   - https://github.com/dysnix/charts


### PR DESCRIPTION
Bumps chart version to 1.0.0.

We are using this chart flawlessly in prod for several month, now.