### PR TITLE
PowerDNS: Add private reverse zones for transparent DNS

### DIFF
--- a/charts/powerdns-recursor/Chart.yaml
+++ b/charts/powerdns-recursor/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: powerdns-recursor
 description: Helm chart for deploying PowerDNS Recursor on Kubernetes
 type: application
-version: 0.4.2
+version: 0.4.3
 appVersion: 5.4.0
 keywords:
   - dns

--- a/charts/powerdns-recursor/README.md
+++ b/charts/powerdns-recursor/README.md
@@ -1,6 +1,6 @@
 # powerdns-recursor
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.4.0](https://img.shields.io/badge/AppVersion-5.4.0-informational?style=flat-square)
+![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.4.0](https://img.shields.io/badge/AppVersion-5.4.0-informational?style=flat-square)
 
 Helm chart for deploying PowerDNS Recursor on Kubernetes
 

--- a/charts/powerdns-recursor/templates/_helpers.tpl
+++ b/charts/powerdns-recursor/templates/_helpers.tpl
@@ -312,6 +312,34 @@ Effective tolerations.
 {{- end }}
 
 {{/*
+Private reverse lookup zones forwarded to CoreDNS in transparent DNS mode.
+*/}}
+{{- define "pdns.transparentDNSPrivateReverseZones" -}}
+{{- $zones := list
+    "10.in-addr.arpa"
+    "16.172.in-addr.arpa"
+    "17.172.in-addr.arpa"
+    "18.172.in-addr.arpa"
+    "19.172.in-addr.arpa"
+    "20.172.in-addr.arpa"
+    "21.172.in-addr.arpa"
+    "22.172.in-addr.arpa"
+    "23.172.in-addr.arpa"
+    "24.172.in-addr.arpa"
+    "25.172.in-addr.arpa"
+    "26.172.in-addr.arpa"
+    "27.172.in-addr.arpa"
+    "28.172.in-addr.arpa"
+    "29.172.in-addr.arpa"
+    "30.172.in-addr.arpa"
+    "31.172.in-addr.arpa"
+    "168.192.in-addr.arpa"
+    "c.f.ip6.arpa"
+    "d.f.ip6.arpa" -}}
+{{- toYaml $zones -}}
+{{- end }}
+
+{{/*
 Rendered PDNS config with transparent DNS forwarding when enabled.
 */}}
 {{- define "pdns.config" -}}
@@ -324,17 +352,18 @@ Rendered PDNS config with transparent DNS forwarding when enabled.
 {{- $recursor := default (dict) (get $config "recursor") -}}
 {{- $existing := default (list) (get $recursor "forward_zones") -}}
 {{- $upstreamIP := include "pdns.transparentDNSClusterDNSIP" . -}}
-{{- $transparentZones := list .Values.transparentDNS.clusterDomain "in-addr.arpa" "ip6.arpa" -}}
+{{- $privateReverseZones := fromYamlArray (include "pdns.transparentDNSPrivateReverseZones" .) -}}
+{{- $transparentZones := concat (list .Values.transparentDNS.clusterDomain) $privateReverseZones -}}
 {{- $filtered := list -}}
 {{- range $entry := $existing -}}
   {{- if not (and (kindIs "map" $entry) (has (get $entry "zone") $transparentZones)) -}}
     {{- $filtered = append $filtered $entry -}}
   {{- end -}}
 {{- end -}}
-{{- $zones := list
-    (dict "zone" .Values.transparentDNS.clusterDomain "forwarders" (list (printf "%s:53" $upstreamIP)))
-    (dict "zone" "in-addr.arpa" "forwarders" (list (printf "%s:53" $upstreamIP)))
-    (dict "zone" "ip6.arpa" "forwarders" (list (printf "%s:53" $upstreamIP))) -}}
+{{- $zones := list (dict "zone" .Values.transparentDNS.clusterDomain "forwarders" (list (printf "%s:53" $upstreamIP))) -}}
+{{- range $zone := $privateReverseZones -}}
+{{- $zones = append $zones (dict "zone" $zone "forwarders" (list (printf "%s:53" $upstreamIP))) -}}
+{{- end -}}
 {{- $_ := set $recursor "forward_zones" (concat $filtered $zones) -}}
 {{- $_ := set $config "recursor" $recursor -}}
 {{- end -}}

--- a/charts/powerdns-recursor/tests/powerdns_recursor_test.yaml
+++ b/charts/powerdns-recursor/tests/powerdns_recursor_test.yaml
@@ -375,6 +375,22 @@ tests:
         template: templates/configmaps.yaml
       - matchRegex:
           path: data["recursor.yml"]
+          pattern: "zone: 10\\.in-addr\\.arpa[\\s\\S]*172\\.20\\.0\\.11:53"
+        template: templates/configmaps.yaml
+      - matchRegex:
+          path: data["recursor.yml"]
+          pattern: "zone: 168\\.192\\.in-addr\\.arpa[\\s\\S]*172\\.20\\.0\\.11:53"
+        template: templates/configmaps.yaml
+      - notMatchRegex:
+          path: data["recursor.yml"]
+          pattern: "zone: in-addr\\.arpa"
+        template: templates/configmaps.yaml
+      - notMatchRegex:
+          path: data["recursor.yml"]
+          pattern: "zone: ip6\\.arpa"
+        template: templates/configmaps.yaml
+      - matchRegex:
+          path: data["recursor.yml"]
           pattern: "incoming:[\\s\\S]*listen:[\\s\\S]*- 169\\.254\\.20\\.10[\\s\\S]*- 172\\.20\\.0\\.10[\\s\\S]*- 10\\.43\\.0\\.53[\\s\\S]*- 10\\.43\\.0\\.54[\\s\\S]*port: 53"
         template: templates/configmaps.yaml
       - isKind:
@@ -433,6 +449,10 @@ tests:
       - notMatchRegex:
           path: data["recursor.yml"]
           pattern: "10\\.0\\.0\\.53:53"
+        template: templates/configmaps.yaml
+      - matchRegex:
+          path: data["recursor.yml"]
+          pattern: "zone: 10\\.in-addr\\.arpa"
         template: templates/configmaps.yaml
       - matchRegex:
           path: data["recursor.yml"]


### PR DESCRIPTION
Forward private IPv4 and IPv6 reverse zones to CoreDNS Avoid forwarding entire in-addr.arpa and ip6.arpa zones Updated chart version to 0.4.3
Added tests for new reverse zone behavior