### PR TITLE
Add cronjob timezone support and fix RabbitMQ user tags rendering

### DIFF
--- a/charts/cronjobs/Chart.yaml
+++ b/charts/cronjobs/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: cronjobs
 description: A generic helm cronjob chart for kubernetes
 type: application
-version: 1.6.5
+version: 1.6.6
 appVersion: latest
 home: https://github.com/klicktipp/helm-charts
 keywords:

--- a/charts/cronjobs/README.md
+++ b/charts/cronjobs/README.md
@@ -1,6 +1,6 @@
 # cronjobs
 
-![Version: 1.6.5](https://img.shields.io/badge/Version-1.6.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.6.6](https://img.shields.io/badge/Version-1.6.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 A generic helm cronjob chart for kubernetes
 
@@ -23,6 +23,7 @@ A generic helm cronjob chart for kubernetes
 | configMaps | object | `{}` | Configure configMaps. |
 | secretEnvFrom | list | `[]` | Set secretEnvFrom. |
 | env | object | `{}` | Environment variable entries. |
+| timezone | string | `""` | Default time zone for all CronJobs. Individual jobs can override this value. |
 | jobs | object | `{}` | Configure jobs. |
 | serviceAccount | object | `{"annotations":{},"automount":true,"create":true,"name":""}` | ServiceAccount configuration. |
 | serviceAccount.create | bool | `true` | Set serviceAccount.create. |

--- a/charts/cronjobs/templates/cronjob.yaml
+++ b/charts/cronjobs/templates/cronjob.yaml
@@ -5,6 +5,7 @@
 {{- $JOB_NAME_SLUG := include "com.klicktipp.slugify-volume-name" $job_name }}
 {{- $env := mergeOverwrite dict $.Values.env ($job.env | default dict) }}
 {{- $image := mergeOverwrite dict ($.Values.image | default dict) ($job.image | default dict) }}
+{{- $timezone := $job.timezone | default $.Values.timezone }}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -25,6 +26,9 @@ spec:
   failedJobsHistoryLimit: {{ default 1 .failedJobsHistoryLimit }}
   successfulJobsHistoryLimit: {{ default 1 .successfulJobsHistoryLimit }}
   schedule: {{ .schedule | quote }}
+  {{- with $timezone }}
+  timeZone: {{ . | quote }}
+  {{- end }}
   suspend: {{ .suspend | default false }}
   {{- if .startingDeadlineSeconds }}
   startingDeadlineSeconds: {{ .startingDeadlineSeconds }}

--- a/charts/cronjobs/values.yaml
+++ b/charts/cronjobs/values.yaml
@@ -66,11 +66,15 @@ secretEnvFrom: []
 # -- Environment variable entries.
 env: {}
 
+# -- Default time zone for all CronJobs. Individual jobs can override this value.
+timezone: ""
+
 # -- Configure jobs.
 jobs: {}
 #  test:
 #    containerName: cronjob
 #    schedule: "*/5 * * * *"
+#    timezone: "Europe/Berlin"
 #    command:
 #      - /bin/sh
 #      - -c


### PR DESCRIPTION
## Summary
- add optional `timezone` support to the `cronjobs` chart with chart-level defaults and per-job overrides
- render `spec.timeZone` only when a timezone is configured
- bump the `cronjobs` chart version to `1.6.6` and update generated README docs
- fix `rabbitmq-topology` user tag rendering by emitting tags as JSON

## Testing
- `scripts/check-values-docs.sh charts/cronjobs/values.yaml`
- `helm template` for `charts/cronjobs` with `timezone=Europe/Berlin`
- `scripts/check-readme-consistency.sh charts/cronjobs`