### PR TITLE
[cronjobs] add jitter initcontainer

### DIFF
--- a/charts/cronjobs/Chart.yaml
+++ b/charts/cronjobs/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: cronjobs
 description: A generic helm cronjob chart for kubernetes
 type: application
-version: 1.6.6
+version: 1.7.0
 appVersion: latest
 home: https://github.com/klicktipp/helm-charts
 keywords:

--- a/charts/cronjobs/README.md
+++ b/charts/cronjobs/README.md
@@ -24,6 +24,14 @@ A generic helm cronjob chart for kubernetes
 | secretEnvFrom | list | `[]` | Set secretEnvFrom. |
 | env | object | `{}` | Environment variable entries. |
 | timezone | string | `""` | Default time zone for all CronJobs. Individual jobs can override this value. |
+| startupJitter | object | `{"enabled":false,"image":{"pullPolicy":"IfNotPresent","repository":"bash","tag":"5.2"},"maxSeconds":60,"seed":"cronjobs-jitter"}` | Startup jitter settings for all jobs. Individual jobs can override these values. |
+| startupJitter.enabled | bool | `false` | Enable startup jitter initContainer. |
+| startupJitter.maxSeconds | int | `60` | Maximum startup delay in seconds. Effective delay is between 0 and this value. |
+| startupJitter.seed | string | `"cronjobs-jitter"` | Seed prefix combined with namespace for pseudo-random delay generation. |
+| startupJitter.image | object | `{"pullPolicy":"IfNotPresent","repository":"bash","tag":"5.2"}` | Jitter initContainer image settings. |
+| startupJitter.image.repository | string | `"bash"` | Container image repository. |
+| startupJitter.image.tag | string | `"5.2"` | Container image tag. |
+| startupJitter.image.pullPolicy | string | `"IfNotPresent"` | Container image pull policy. |
 | jobs | object | `{}` | Configure jobs. |
 | serviceAccount | object | `{"annotations":{},"automount":true,"create":true,"name":""}` | ServiceAccount configuration. |
 | serviceAccount.create | bool | `true` | Set serviceAccount.create. |

--- a/charts/cronjobs/README.md
+++ b/charts/cronjobs/README.md
@@ -24,11 +24,12 @@ A generic helm cronjob chart for kubernetes
 | secretEnvFrom | list | `[]` | Set secretEnvFrom. |
 | env | object | `{}` | Environment variable entries. |
 | timezone | string | `""` | Default time zone for all CronJobs. Individual jobs can override this value. |
-| startupJitter | object | `{"enabled":false,"image":{"pullPolicy":"IfNotPresent","repository":"bash","tag":"5.3"},"maxSeconds":60,"seed":"cronjobs-jitter"}` | Startup jitter settings for all jobs. Individual jobs can override these values. |
+| startupJitter | object | `{"enabled":false,"image":{"pullPolicy":"IfNotPresent","registry":"docker.io","repository":"bash","tag":"5.3"},"maxSeconds":60,"seed":"cronjobs-jitter"}` | Startup jitter settings for all jobs. Individual jobs can override these values. |
 | startupJitter.enabled | bool | `false` | Enable startup jitter initContainer. |
 | startupJitter.maxSeconds | int | `60` | Maximum startup delay in seconds. The effective delay is between 0 and this value. |
 | startupJitter.seed | string | `"cronjobs-jitter"` | Seed prefix combined with namespace for pseudo-random delay generation. |
-| startupJitter.image | object | `{"pullPolicy":"IfNotPresent","repository":"bash","tag":"5.3"}` | Jitter initContainer image settings. |
+| startupJitter.image | object | `{"pullPolicy":"IfNotPresent","registry":"docker.io","repository":"bash","tag":"5.3"}` | Jitter initContainer image settings. |
+| startupJitter.image.registry | string | `"docker.io"` | Container image registry. |
 | startupJitter.image.repository | string | `"bash"` | Container image repository. |
 | startupJitter.image.tag | string | `"5.3"` | Container image tag. |
 | startupJitter.image.pullPolicy | string | `"IfNotPresent"` | Container image pull policy. |

--- a/charts/cronjobs/README.md
+++ b/charts/cronjobs/README.md
@@ -1,6 +1,6 @@
 # cronjobs
 
-![Version: 1.6.6](https://img.shields.io/badge/Version-1.6.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 A generic helm cronjob chart for kubernetes
 
@@ -24,13 +24,13 @@ A generic helm cronjob chart for kubernetes
 | secretEnvFrom | list | `[]` | Set secretEnvFrom. |
 | env | object | `{}` | Environment variable entries. |
 | timezone | string | `""` | Default time zone for all CronJobs. Individual jobs can override this value. |
-| startupJitter | object | `{"enabled":false,"image":{"pullPolicy":"IfNotPresent","repository":"bash","tag":"5.2"},"maxSeconds":60,"seed":"cronjobs-jitter"}` | Startup jitter settings for all jobs. Individual jobs can override these values. |
+| startupJitter | object | `{"enabled":false,"image":{"pullPolicy":"IfNotPresent","repository":"bash","tag":"5.3"},"maxSeconds":60,"seed":"cronjobs-jitter"}` | Startup jitter settings for all jobs. Individual jobs can override these values. |
 | startupJitter.enabled | bool | `false` | Enable startup jitter initContainer. |
-| startupJitter.maxSeconds | int | `60` | Maximum startup delay in seconds. Effective delay is between 0 and this value. |
+| startupJitter.maxSeconds | int | `60` | Maximum startup delay in seconds. The effective delay is between 0 and this value. |
 | startupJitter.seed | string | `"cronjobs-jitter"` | Seed prefix combined with namespace for pseudo-random delay generation. |
-| startupJitter.image | object | `{"pullPolicy":"IfNotPresent","repository":"bash","tag":"5.2"}` | Jitter initContainer image settings. |
+| startupJitter.image | object | `{"pullPolicy":"IfNotPresent","repository":"bash","tag":"5.3"}` | Jitter initContainer image settings. |
 | startupJitter.image.repository | string | `"bash"` | Container image repository. |
-| startupJitter.image.tag | string | `"5.2"` | Container image tag. |
+| startupJitter.image.tag | string | `"5.3"` | Container image tag. |
 | startupJitter.image.pullPolicy | string | `"IfNotPresent"` | Container image pull policy. |
 | jobs | object | `{}` | Configure jobs. |
 | serviceAccount | object | `{"annotations":{},"automount":true,"create":true,"name":""}` | ServiceAccount configuration. |

--- a/charts/cronjobs/templates/_helpers.tpl
+++ b/charts/cronjobs/templates/_helpers.tpl
@@ -61,6 +61,19 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Return the fully qualified startup jitter image reference.
+*/}}
+{{- define "cronjobs.startupJitterImage" -}}
+{{- $repository := .repository | default "bash" -}}
+{{- $tag := .tag | default "5.3" -}}
+{{- if .registry -}}
+{{- printf "%s/%s:%s" .registry $repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Given a list of strings, concatenate all of them with a dash ("-")
 and slugify the string to be DNS name compatible
 */}}

--- a/charts/cronjobs/templates/_helpers.tpl
+++ b/charts/cronjobs/templates/_helpers.tpl
@@ -68,3 +68,15 @@ and slugify the string to be DNS name compatible
 {{- $r := (join "-" .) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trunc 63 | trimSuffix "-" }}
 {{- $r }}
 {{- end -}}
+
+{{/*
+Generate deterministic startup delay seconds from seed parts.
+*/}}
+{{- define "com.klicktipp.generateStartupDelaySeconds" -}}
+{{- $seed := join "-" (index . "seed") -}}
+{{- $exceptionList := list "prod" "staging" -}}
+{{- $hash := sha256sum $seed -}}
+{{- $intFromHash := int64 (printf "%x" (substr 0 8 $hash)) -}}
+{{- $maxSeconds := int (default 60 (index . "maxSeconds")) -}}
+{{- mod $intFromHash (add $maxSeconds 1) -}}
+{{- end -}}

--- a/charts/cronjobs/templates/cronjob.yaml
+++ b/charts/cronjobs/templates/cronjob.yaml
@@ -96,7 +96,9 @@ spec:
               command:
                 - /usr/local/bin/bash
                 - -ec
-                - sleep {{ $startupDelaySeconds }}
+                - |
+                  echo "Startup jitter delay: {{ $startupDelaySeconds }}s"
+                  sleep {{ $startupDelaySeconds }}
           {{- end }}
           containers:
             - name: {{ .containerName | default ($.Values.commonContainerName | default $JOB_NAME_SLUG) }}

--- a/charts/cronjobs/templates/cronjob.yaml
+++ b/charts/cronjobs/templates/cronjob.yaml
@@ -91,7 +91,7 @@ spec:
           {{- if $startupJitter.enabled }}
           initContainers:
             - name: jitter
-              image: "{{ $jitterImage.repository | default "bash" }}:{{ $jitterImage.tag | default "5.2" }}"
+              image: {{ include "cronjobs.startupJitterImage" $jitterImage | quote }}
               imagePullPolicy: {{ $jitterImage.pullPolicy | default "IfNotPresent" }}
               command:
                 - /usr/local/bin/bash

--- a/charts/cronjobs/templates/cronjob.yaml
+++ b/charts/cronjobs/templates/cronjob.yaml
@@ -6,6 +6,8 @@
 {{- $env := mergeOverwrite dict $.Values.env ($job.env | default dict) }}
 {{- $image := mergeOverwrite dict ($.Values.image | default dict) ($job.image | default dict) }}
 {{- $timezone := $job.timezone | default $.Values.timezone }}
+{{- $startupJitter := mergeOverwrite dict ($.Values.startupJitter | default dict) ($job.startupJitter | default dict) }}
+{{- $jitterImage := $startupJitter.image | default dict }}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -83,6 +85,16 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml ($job.podSecurityContext | default $.Values.podSecurityContext) | nindent 12 }}
+          {{- if $startupJitter.enabled }}
+          initContainers:
+            - name: jitter
+              image: "{{ $jitterImage.repository | default "bash" }}:{{ $jitterImage.tag | default "5.2" }}"
+              imagePullPolicy: {{ $jitterImage.pullPolicy | default "IfNotPresent" }}
+              command:
+                - /usr/local/bin/bash
+                - -ec
+                - sleep {{ include "com.klicktipp.generateStartupDelaySeconds" (dict "seed" (list ($startupJitter.seed | default "cronjobs-jitter") $.Release.Namespace $JOB_NAME_SLUG) "maxSeconds" ($startupJitter.maxSeconds | default 60)) }}
+          {{- end }}
           containers:
             - name: {{ .containerName | default ($.Values.commonContainerName | default $JOB_NAME_SLUG) }}
               securityContext:

--- a/charts/cronjobs/templates/cronjob.yaml
+++ b/charts/cronjobs/templates/cronjob.yaml
@@ -8,6 +8,9 @@
 {{- $timezone := $job.timezone | default $.Values.timezone }}
 {{- $startupJitter := mergeOverwrite dict ($.Values.startupJitter | default dict) ($job.startupJitter | default dict) }}
 {{- $jitterImage := $startupJitter.image | default dict }}
+{{- $startupJitterSeed := $startupJitter.seed | default "cronjobs-jitter" }}
+{{- $startupJitterMaxSeconds := $startupJitter.maxSeconds | default 60 }}
+{{- $startupDelaySeconds := include "com.klicktipp.generateStartupDelaySeconds" (dict "seed" (list $startupJitterSeed $.Release.Namespace $JOB_NAME_SLUG) "maxSeconds" $startupJitterMaxSeconds) }}
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -93,7 +96,7 @@ spec:
               command:
                 - /usr/local/bin/bash
                 - -ec
-                - sleep {{ include "com.klicktipp.generateStartupDelaySeconds" (dict "seed" (list ($startupJitter.seed | default "cronjobs-jitter") $.Release.Namespace $JOB_NAME_SLUG) "maxSeconds" ($startupJitter.maxSeconds | default 60)) }}
+                - sleep {{ $startupDelaySeconds }}
           {{- end }}
           containers:
             - name: {{ .containerName | default ($.Values.commonContainerName | default $JOB_NAME_SLUG) }}

--- a/charts/cronjobs/values.yaml
+++ b/charts/cronjobs/values.yaml
@@ -69,6 +69,23 @@ env: {}
 # -- Default time zone for all CronJobs. Individual jobs can override this value.
 timezone: ""
 
+# -- Startup jitter settings for all jobs. Individual jobs can override these values.
+startupJitter:
+  # -- Enable startup jitter initContainer.
+  enabled: false
+  # -- Maximum startup delay in seconds. The effective delay is between 0 and this value.
+  maxSeconds: 60
+  # -- Seed prefix combined with namespace for pseudo-random delay generation.
+  seed: "cronjobs-jitter"
+  # -- Jitter initContainer image settings.
+  image:
+    # -- Container image repository.
+    repository: bash
+    # -- Container image tag.
+    tag: "5.2"
+    # -- Container image pull policy.
+    pullPolicy: IfNotPresent
+
 # -- Configure jobs.
 jobs: {}
 #  test:
@@ -84,6 +101,14 @@ jobs: {}
 #      repository: alpine
 #      tag: latest
 #      pullPolicy: IfNotPresent
+#    startupJitter:
+#      enabled: true
+#      maxSeconds: 60
+#      seed: "my-team"
+#      image:
+#        repository: bash
+#        tag: "5.2"
+#        pullPolicy: IfNotPresent
 #    # see https://github.com/kubernetes/kubernetes/issues/74848#issuecomment-475178355
 #    restartPolicy: Never
 #    startingDeadlineSeconds: 60

--- a/charts/cronjobs/values.yaml
+++ b/charts/cronjobs/values.yaml
@@ -79,6 +79,8 @@ startupJitter:
   seed: "cronjobs-jitter"
   # -- Jitter initContainer image settings.
   image:
+    # -- Container image registry.
+    registry: "docker.io"
     # -- Container image repository.
     repository: bash
     # -- Container image tag.
@@ -106,8 +108,9 @@ jobs: {}
 #      maxSeconds: 60
 #      seed: "my-team"
 #      image:
+#        registry: "docker.io"
 #        repository: bash
-#        tag: "5.2"
+#        tag: "5.3"
 #        pullPolicy: IfNotPresent
 #    # see https://github.com/kubernetes/kubernetes/issues/74848#issuecomment-475178355
 #    restartPolicy: Never

--- a/charts/cronjobs/values.yaml
+++ b/charts/cronjobs/values.yaml
@@ -82,7 +82,7 @@ startupJitter:
     # -- Container image repository.
     repository: bash
     # -- Container image tag.
-    tag: "5.2"
+    tag: "5.3"
     # -- Container image pull policy.
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
* Add optional `startupJitter` support to the cronjobs chart via a jitter `initContainer` so jobs can start with a bounded delay.
* Compute delay deterministically in Helm templates using `startupJitter.seed`, `release namespace`, and job slug, capped by `startupJitter.maxSeconds`.
