### PR TITLE
Add Helm chart for snds-exporter

### DIFF
--- a/charts/snds-exporter/.helmignore
+++ b/charts/snds-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/snds-exporter/Chart.yaml
+++ b/charts/snds-exporter/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: snds-exporter
+description: A Helm chart for running the snds-exporter with OAuth token files in Kubernetes.
+type: application
+version: 0.2.0
+appVersion: "0.2.2"
+keywords:
+  - snds
+  - exporter
+  - prometheus
+  - microsoft
+home: https://github.com/klicktipp/helm-charts
+sources:
+  - https://github.com/klicktipp/helm-charts
+maintainers:
+  - name: vquie
+    url: https://github.com/vquie

--- a/charts/snds-exporter/README.md
+++ b/charts/snds-exporter/README.md
@@ -111,26 +111,26 @@ The chart creates the required Role and RoleBinding for this Secret patch flow w
 | auth.refresh.patchKubernetesSecret.secretNamespace | string | `""` | Secret namespace to patch. Defaults to the release namespace. |
 | auth.refresh.patchKubernetesSecret.accessTokenKey | string | `"access-token"` | Secret key updated with the refreshed access token. |
 | auth.refresh.patchKubernetesSecret.tokenCacheKey | string | `"token-cache.json"` | Secret key updated with the refreshed token cache content. |
-| exporter | object | `{"cacheSeconds":300,"debugUnknownResponses":false,"requestTimeout":10,"restApiLookbackDays":3,"restApiUrl":"https://substrate.office.com/ip-domain-management-snds/api/report/data","statusApiUrl":"https://substrate.office.com/ip-domain-management-snds/api/report/status/ip","userAgent":"kt-snds-exporter/1.0","verifyTls":true}` | snds-exporter runtime configuration. |
+| exporter | object | `{"cacheSeconds":3600,"debugUnknownResponses":false,"requestTimeout":10,"restApiLookbackDays":3,"restApiUrl":"https://substrate.office.com/ip-domain-management-snds/api/report/data","statusApiUrl":"https://substrate.office.com/ip-domain-management-snds/api/report/status/ip","userAgent":"kt-snds-exporter/1.0","verifyTls":true}` | snds-exporter runtime configuration. |
 | exporter.restApiUrl | string | `"https://substrate.office.com/ip-domain-management-snds/api/report/data"` | SNDS REST API endpoint returning report data. |
 | exporter.statusApiUrl | string | `"https://substrate.office.com/ip-domain-management-snds/api/report/status/ip"` | SNDS status API endpoint returning IP status information. |
 | exporter.restApiLookbackDays | int | `3` | Number of days requested from the report API. |
 | exporter.requestTimeout | int | `10` | HTTP request timeout in seconds for SNDS API calls. |
-| exporter.cacheSeconds | int | `300` | Response cache duration in seconds. |
+| exporter.cacheSeconds | int | `3600` | Response cache duration in seconds. |
 | exporter.verifyTls | bool | `true` | Verify TLS certificates for outbound HTTPS requests. |
 | exporter.userAgent | string | `"kt-snds-exporter/1.0"` | Custom User-Agent header sent to SNDS APIs. |
 | exporter.debugUnknownResponses | bool | `false` | Log unexpected API responses for debugging. |
 | extraEnv | list | `[]` | Additional environment variables appended to the container. |
 | extraVolumeMounts | list | `[]` | Additional volume mounts appended to the container. |
 | extraVolumes | list | `[]` | Additional volumes appended to the pod. |
-| serviceMonitor | object | `{"selfMonitor":{"additionalMetricsRelabels":{},"additionalRelabeling":[{"action":"labeldrop","regex":"(instance|pod)"}],"enabled":true,"interval":"300s","labels":{},"path":"/metrics","scrapeTimeout":"60s"}}` | Prometheus Operator ServiceMonitor configuration. |
-| serviceMonitor.selfMonitor | object | `{"additionalMetricsRelabels":{},"additionalRelabeling":[{"action":"labeldrop","regex":"(instance|pod)"}],"enabled":true,"interval":"300s","labels":{},"path":"/metrics","scrapeTimeout":"60s"}` | Self-monitoring configuration for the exporter Service. |
+| serviceMonitor | object | `{"selfMonitor":{"additionalMetricsRelabels":{},"additionalRelabeling":[{"action":"labeldrop","regex":"(instance|pod)"}],"enabled":true,"interval":"1h","labels":{},"path":"/metrics","scrapeTimeout":"60s"}}` | Prometheus Operator ServiceMonitor configuration. |
+| serviceMonitor.selfMonitor | object | `{"additionalMetricsRelabels":{},"additionalRelabeling":[{"action":"labeldrop","regex":"(instance|pod)"}],"enabled":true,"interval":"1h","labels":{},"path":"/metrics","scrapeTimeout":"60s"}` | Self-monitoring configuration for the exporter Service. |
 | serviceMonitor.selfMonitor.enabled | bool | `true` | Create a ServiceMonitor when the CRD is available. |
 | serviceMonitor.selfMonitor.path | string | `"/metrics"` | Metrics path scraped by Prometheus. |
 | serviceMonitor.selfMonitor.additionalMetricsRelabels | object | `{}` | Extra metric relabeling rules for scraped metrics. |
 | serviceMonitor.selfMonitor.additionalRelabeling | list | `[{"action":"labeldrop","regex":"(instance|pod)"}]` | Extra target relabeling rules for the ServiceMonitor endpoint. |
 | serviceMonitor.selfMonitor.labels | object | `{}` | Additional labels added to the ServiceMonitor. |
-| serviceMonitor.selfMonitor.interval | string | `"300s"` | Prometheus scrape interval. |
+| serviceMonitor.selfMonitor.interval | string | `"1h"` | Prometheus scrape interval. |
 | serviceMonitor.selfMonitor.scrapeTimeout | string | `"60s"` | Prometheus scrape timeout. |
 | livenessProbe | object | `{"httpGet":{"path":"/livez","port":"http"}}` | Liveness probe configuration for the exporter container. |
 | readinessProbe | object | `{"httpGet":{"path":"/healthz","port":"http"}}` | Readiness probe configuration for the exporter container. |

--- a/charts/snds-exporter/README.md
+++ b/charts/snds-exporter/README.md
@@ -1,0 +1,142 @@
+# snds-exporter
+
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.2](https://img.shields.io/badge/AppVersion-0.2.2-informational?style=flat-square)
+
+A Helm chart for running the snds-exporter with OAuth token files in Kubernetes.
+
+**Homepage:** <https://github.com/klicktipp/helm-charts>
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| vquie |  | <https://github.com/vquie> |
+## Source Code
+
+* <https://github.com/klicktipp/helm-charts>
+
+## Authentication Model
+
+The chart expects two pieces of token state in the mounted Secret:
+
+- `access-token`: the current OAuth bearer token used for SNDS API requests
+- `token-cache.json`: the cached refresh-token state used for silent token renewal
+
+The exporter can renew tokens headlessly only when both files exist and the initial interactive login was completed with refresh-token cache creation. If `token-cache.json` is missing or no longer usable, silent refresh cannot work and a human must perform the login flow again.
+
+## Initial Login
+
+After the first pod start, you must perform one manual interactive login to seed the SNDS access token and refresh-token cache. The exporter cannot complete the initial OAuth authorization code flow on its own.
+
+The chart bootstraps the token Secret empty by default so the pod can start before login is completed. Until valid token state exists, `/metrics` will log authentication errors.
+
+The recommended Kubernetes bootstrap flow is:
+
+1. Deploy the chart and wait until the pod is running.
+2. Run the interactive login inside the running pod:
+
+```sh
+kubectl exec -it deploy/snds-exporter -- python3 /usr/local/bin/snds_token_helper.py
+```
+
+3. Open the Microsoft login URL printed by the helper in your local browser, complete the login, then paste the final redirect URL back into the terminal.
+4. Restart the workload once so the exporter reliably reopens the updated Secret contents:
+
+```sh
+kubectl rollout restart deployment/snds-exporter
+```
+
+If your release name or namespace differs, adjust the resource name accordingly, for example:
+
+```sh
+kubectl -n monitoring exec -it deploy/my-snds-exporter -- python3 /usr/local/bin/snds_token_helper.py
+kubectl -n monitoring rollout restart deployment/my-snds-exporter
+```
+
+## Secret Persistence
+
+When `auth.refresh.patchKubernetesSecret.enabled=true`, the exporter updates the Kubernetes Secret after a successful token refresh so the latest token state survives pod restarts.
+
+By default, the exporter patches the same Secret it mounts for startup token files. You can override the target Secret name, namespace, and keys with:
+
+- `auth.refresh.patchKubernetesSecret.secretName`
+- `auth.refresh.patchKubernetesSecret.secretNamespace`
+- `auth.refresh.patchKubernetesSecret.accessTokenKey`
+- `auth.refresh.patchKubernetesSecret.tokenCacheKey`
+
+The chart creates the required Role and RoleBinding for this Secret patch flow when secret patching is enabled.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| replicaCount | int | `1` | Number of snds-exporter pods to run. |
+| image | object | `{"pullPolicy":"IfNotPresent","registry":"ghcr.io/klicktipp","repository":"snds-exporter","tag":""}` | Container image configuration. |
+| image.registry | string | `"ghcr.io/klicktipp"` | Optional image registry prefix. |
+| image.repository | string | `"snds-exporter"` | Image repository name. |
+| image.tag | string | `""` | Image tag. When empty, the chart appVersion is used. |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
+| imagePullSecrets | list | `[]` | Image pull secrets for the pod. |
+| nameOverride | string | `""` | Partially override generated resource names. |
+| fullnameOverride | string | `""` | Fully override generated resource names. |
+| namespaceOverride | string | `""` | Override the namespace used for namespaced resources. |
+| serviceAccount | object | `{"annotations":{},"automount":true,"create":true,"name":""}` | ServiceAccount configuration. |
+| serviceAccount.create | bool | `true` | Create a dedicated ServiceAccount. |
+| serviceAccount.automount | bool | `true` | Mount the ServiceAccount token into the pod. |
+| serviceAccount.annotations | object | `{}` | ServiceAccount annotations. |
+| serviceAccount.name | string | `""` | Existing ServiceAccount name to use. When empty, a name is generated. |
+| podAnnotations | object | `{}` | Extra annotations added to the pod template. |
+| podLabels | object | `{}` | Extra labels added to the pod template. |
+| podSecurityContext | object | `{}` | Pod-level security context. |
+| securityContext | object | `{}` | Container-level security context. |
+| service | object | `{"port":9100,"type":"ClusterIP"}` | Service configuration. |
+| service.type | string | `"ClusterIP"` | Kubernetes Service type. |
+| service.port | int | `9100` | Metrics port exposed by the Service and container. |
+| resources | object | `{}` | CPU and memory requests/limits for the container. |
+| auth | object | `{"mountPath":"/var/run/snds-exporter","refresh":{"beforeSeconds":600,"enabled":true,"patchKubernetesSecret":{"accessTokenKey":"access-token","enabled":true,"secretName":"","secretNamespace":"","tokenCacheKey":"token-cache.json"}},"secret":{"accessToken":"","accessTokenKey":"access-token","annotations":{},"create":true,"name":"","tokenCache":"","tokenCacheKey":"token-cache.json"}}` | Authentication and token refresh settings. |
+| auth.mountPath | string | `"/var/run/snds-exporter"` | Mount path for SNDS token files inside the container. |
+| auth.secret | object | `{"accessToken":"","accessTokenKey":"access-token","annotations":{},"create":true,"name":"","tokenCache":"","tokenCacheKey":"token-cache.json"}` | Secret configuration for access token and cache files. |
+| auth.secret.create | bool | `true` | Create the auth Secret from values in this chart. |
+| auth.secret.name | string | `""` | Existing Secret name. When empty, a name is generated. |
+| auth.secret.accessTokenKey | string | `"access-token"` | Secret key containing the access token. |
+| auth.secret.tokenCacheKey | string | `"token-cache.json"` | Secret key containing the token cache file. |
+| auth.secret.annotations | object | `{}` | Annotations added to the generated Secret. |
+| auth.secret.accessToken | string | `""` | Access token content written to the generated Secret. |
+| auth.secret.tokenCache | string | `""` | Token cache JSON content written to the generated Secret. |
+| auth.refresh | object | `{"beforeSeconds":600,"enabled":true,"patchKubernetesSecret":{"accessTokenKey":"access-token","enabled":true,"secretName":"","secretNamespace":"","tokenCacheKey":"token-cache.json"}}` | Token refresh integration settings. |
+| auth.refresh.enabled | bool | `true` | Enable automatic OAuth token refresh inside the exporter. |
+| auth.refresh.beforeSeconds | int | `600` | Refresh the token this many seconds before expiry. |
+| auth.refresh.patchKubernetesSecret | object | `{"accessTokenKey":"access-token","enabled":true,"secretName":"","secretNamespace":"","tokenCacheKey":"token-cache.json"}` | Kubernetes Secret patch settings used after token refresh. |
+| auth.refresh.patchKubernetesSecret.enabled | bool | `true` | Allow the exporter to patch the Secret after refreshing tokens. |
+| auth.refresh.patchKubernetesSecret.secretName | string | `""` | Secret name to patch. Defaults to the auth Secret name. |
+| auth.refresh.patchKubernetesSecret.secretNamespace | string | `""` | Secret namespace to patch. Defaults to the release namespace. |
+| auth.refresh.patchKubernetesSecret.accessTokenKey | string | `"access-token"` | Secret key updated with the refreshed access token. |
+| auth.refresh.patchKubernetesSecret.tokenCacheKey | string | `"token-cache.json"` | Secret key updated with the refreshed token cache content. |
+| exporter | object | `{"cacheSeconds":300,"debugUnknownResponses":false,"requestTimeout":10,"restApiLookbackDays":3,"restApiUrl":"https://substrate.office.com/ip-domain-management-snds/api/report/data","statusApiUrl":"https://substrate.office.com/ip-domain-management-snds/api/report/status/ip","userAgent":"kt-snds-exporter/1.0","verifyTls":true}` | snds-exporter runtime configuration. |
+| exporter.restApiUrl | string | `"https://substrate.office.com/ip-domain-management-snds/api/report/data"` | SNDS REST API endpoint returning report data. |
+| exporter.statusApiUrl | string | `"https://substrate.office.com/ip-domain-management-snds/api/report/status/ip"` | SNDS status API endpoint returning IP status information. |
+| exporter.restApiLookbackDays | int | `3` | Number of days requested from the report API. |
+| exporter.requestTimeout | int | `10` | HTTP request timeout in seconds for SNDS API calls. |
+| exporter.cacheSeconds | int | `300` | Response cache duration in seconds. |
+| exporter.verifyTls | bool | `true` | Verify TLS certificates for outbound HTTPS requests. |
+| exporter.userAgent | string | `"kt-snds-exporter/1.0"` | Custom User-Agent header sent to SNDS APIs. |
+| exporter.debugUnknownResponses | bool | `false` | Log unexpected API responses for debugging. |
+| extraEnv | list | `[]` | Additional environment variables appended to the container. |
+| extraVolumeMounts | list | `[]` | Additional volume mounts appended to the container. |
+| extraVolumes | list | `[]` | Additional volumes appended to the pod. |
+| serviceMonitor | object | `{"selfMonitor":{"additionalMetricsRelabels":{},"additionalRelabeling":[{"action":"labeldrop","regex":"(instance|pod)"}],"enabled":true,"interval":"300s","labels":{},"path":"/metrics","scrapeTimeout":"60s"}}` | Prometheus Operator ServiceMonitor configuration. |
+| serviceMonitor.selfMonitor | object | `{"additionalMetricsRelabels":{},"additionalRelabeling":[{"action":"labeldrop","regex":"(instance|pod)"}],"enabled":true,"interval":"300s","labels":{},"path":"/metrics","scrapeTimeout":"60s"}` | Self-monitoring configuration for the exporter Service. |
+| serviceMonitor.selfMonitor.enabled | bool | `true` | Create a ServiceMonitor when the CRD is available. |
+| serviceMonitor.selfMonitor.path | string | `"/metrics"` | Metrics path scraped by Prometheus. |
+| serviceMonitor.selfMonitor.additionalMetricsRelabels | object | `{}` | Extra metric relabeling rules for scraped metrics. |
+| serviceMonitor.selfMonitor.additionalRelabeling | list | `[{"action":"labeldrop","regex":"(instance|pod)"}]` | Extra target relabeling rules for the ServiceMonitor endpoint. |
+| serviceMonitor.selfMonitor.labels | object | `{}` | Additional labels added to the ServiceMonitor. |
+| serviceMonitor.selfMonitor.interval | string | `"300s"` | Prometheus scrape interval. |
+| serviceMonitor.selfMonitor.scrapeTimeout | string | `"60s"` | Prometheus scrape timeout. |
+| livenessProbe | object | `{"httpGet":{"path":"/livez","port":"http"}}` | Liveness probe configuration for the exporter container. |
+| readinessProbe | object | `{"httpGet":{"path":"/healthz","port":"http"}}` | Readiness probe configuration for the exporter container. |
+| nodeSelector | object | `{}` | Node selector for pod scheduling. |
+| tolerations | list | `[]` | Tolerations for pod scheduling. |
+| affinity | object | `{}` | Affinity rules for pod scheduling. |
+
+<!-- BEGIN AUTO EXAMPLES -->
+<!-- END AUTO EXAMPLES -->

--- a/charts/snds-exporter/README.md.gotmpl
+++ b/charts/snds-exporter/README.md.gotmpl
@@ -1,0 +1,67 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+{{ template "chart.maintainersSection" . }}
+{{ template "chart.sourcesSection" . }}
+
+## Authentication Model
+
+The chart expects two pieces of token state in the mounted Secret:
+
+- `access-token`: the current OAuth bearer token used for SNDS API requests
+- `token-cache.json`: the cached refresh-token state used for silent token renewal
+
+The exporter can renew tokens headlessly only when both files exist and the initial interactive login was completed with refresh-token cache creation. If `token-cache.json` is missing or no longer usable, silent refresh cannot work and a human must perform the login flow again.
+
+## Initial Login
+
+After the first pod start, you must perform one manual interactive login to seed the SNDS access token and refresh-token cache. The exporter cannot complete the initial OAuth authorization code flow on its own.
+
+The chart bootstraps the token Secret empty by default so the pod can start before login is completed. Until valid token state exists, `/metrics` will log authentication errors.
+
+The recommended Kubernetes bootstrap flow is:
+
+1. Deploy the chart and wait until the pod is running.
+2. Run the interactive login inside the running pod:
+
+```sh
+kubectl exec -it deploy/snds-exporter -- python3 /usr/local/bin/snds_token_helper.py
+```
+
+3. Open the Microsoft login URL printed by the helper in your local browser, complete the login, then paste the final redirect URL back into the terminal.
+4. Restart the workload once so the exporter reliably reopens the updated Secret contents:
+
+```sh
+kubectl rollout restart deployment/snds-exporter
+```
+
+If your release name or namespace differs, adjust the resource name accordingly, for example:
+
+```sh
+kubectl -n monitoring exec -it deploy/my-snds-exporter -- python3 /usr/local/bin/snds_token_helper.py
+kubectl -n monitoring rollout restart deployment/my-snds-exporter
+```
+
+## Secret Persistence
+
+When `auth.refresh.patchKubernetesSecret.enabled=true`, the exporter updates the Kubernetes Secret after a successful token refresh so the latest token state survives pod restarts.
+
+By default, the exporter patches the same Secret it mounts for startup token files. You can override the target Secret name, namespace, and keys with:
+
+- `auth.refresh.patchKubernetesSecret.secretName`
+- `auth.refresh.patchKubernetesSecret.secretNamespace`
+- `auth.refresh.patchKubernetesSecret.accessTokenKey`
+- `auth.refresh.patchKubernetesSecret.tokenCacheKey`
+
+The chart creates the required Role and RoleBinding for this Secret patch flow when secret patching is enabled.
+
+{{ template "chart.valuesSection" . }}
+
+<!-- BEGIN AUTO EXAMPLES -->
+<!-- END AUTO EXAMPLES -->

--- a/charts/snds-exporter/templates/_helpers.tpl
+++ b/charts/snds-exporter/templates/_helpers.tpl
@@ -1,0 +1,94 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "snds-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "snds-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "snds-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "snds-exporter.labels" -}}
+helm.sh/chart: {{ include "snds-exporter.chart" . }}
+{{ include "snds-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "snds-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "snds-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "snds-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "snds-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "snds-exporter.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "snds-exporter.authSecretName" -}}
+{{- if .Values.auth.secret.name -}}
+{{- .Values.auth.secret.name -}}
+{{- else -}}
+{{- printf "%s-auth" (include "snds-exporter.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "snds-exporter.patchSecretName" -}}
+{{- if .Values.auth.refresh.patchKubernetesSecret.secretName -}}
+{{- .Values.auth.refresh.patchKubernetesSecret.secretName -}}
+{{- else -}}
+{{- include "snds-exporter.authSecretName" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "snds-exporter.patchSecretNamespace" -}}
+{{- if .Values.auth.refresh.patchKubernetesSecret.secretNamespace -}}
+{{- .Values.auth.refresh.patchKubernetesSecret.secretNamespace -}}
+{{- else -}}
+{{- include "snds-exporter.namespace" . -}}
+{{- end -}}
+{{- end -}}

--- a/charts/snds-exporter/templates/deployment.yaml
+++ b/charts/snds-exporter/templates/deployment.yaml
@@ -1,0 +1,112 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "snds-exporter.fullname" . }}
+  labels:
+    {{- include "snds-exporter.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "snds-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "snds-exporter.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "snds-exporter.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ if .Values.image.registry }}{{ .Values.image.registry }}/{{ end }}{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: snds-auth
+              mountPath: {{ .Values.auth.mountPath }}
+              readOnly: true
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          env:
+            - name: SNDS_ACCESS_TOKEN_FILE
+              value: {{ printf "%s/%s" .Values.auth.mountPath .Values.auth.secret.accessTokenKey | quote }}
+            - name: SNDS_TOKEN_CACHE_FILE
+              value: {{ printf "%s/%s" .Values.auth.mountPath .Values.auth.secret.tokenCacheKey | quote }}
+            - name: REST_API_URL
+              value: {{ .Values.exporter.restApiUrl | quote }}
+            - name: STATUS_API_URL
+              value: {{ .Values.exporter.statusApiUrl | quote }}
+            - name: REST_API_LOOKBACK_DAYS
+              value: {{ .Values.exporter.restApiLookbackDays | quote }}
+            - name: REQUEST_TIMEOUT
+              value: {{ .Values.exporter.requestTimeout | quote }}
+            - name: CACHE_SECONDS
+              value: {{ .Values.exporter.cacheSeconds | quote }}
+            - name: VERIFY_TLS
+              value: {{ .Values.exporter.verifyTls | quote }}
+            - name: USER_AGENT
+              value: {{ .Values.exporter.userAgent | quote }}
+            - name: DEBUG_UNKNOWN_RESPONSES
+              value: {{ .Values.exporter.debugUnknownResponses | quote }}
+            {{- if .Values.auth.refresh.enabled }}
+            - name: TOKEN_REFRESH_BEFORE_SECONDS
+              value: {{ .Values.auth.refresh.beforeSeconds | quote }}
+            {{- end }}
+            {{- if .Values.auth.refresh.patchKubernetesSecret.enabled }}
+            - name: K8S_SECRET_NAME
+              value: {{ include "snds-exporter.patchSecretName" . | quote }}
+            {{- if .Values.auth.refresh.patchKubernetesSecret.secretNamespace }}
+            - name: K8S_SECRET_NAMESPACE
+              value: {{ .Values.auth.refresh.patchKubernetesSecret.secretNamespace | quote }}
+            {{- end }}
+            - name: K8S_SECRET_ACCESS_TOKEN_KEY
+              value: {{ .Values.auth.refresh.patchKubernetesSecret.accessTokenKey | quote }}
+            - name: K8S_SECRET_CACHE_KEY
+              value: {{ .Values.auth.refresh.patchKubernetesSecret.tokenCacheKey | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: snds-auth
+          secret:
+            secretName: {{ include "snds-exporter.authSecretName" . }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/snds-exporter/templates/rbac.yaml
+++ b/charts/snds-exporter/templates/rbac.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.auth.refresh.patchKubernetesSecret.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "snds-exporter.fullname" . }}
+  namespace: {{ include "snds-exporter.patchSecretNamespace" . }}
+  labels:
+    {{- include "snds-exporter.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - {{ include "snds-exporter.patchSecretName" . }}
+    verbs: ["get", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "snds-exporter.fullname" . }}
+  namespace: {{ include "snds-exporter.patchSecretNamespace" . }}
+  labels:
+    {{- include "snds-exporter.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "snds-exporter.serviceAccountName" . }}
+    namespace: {{ include "snds-exporter.namespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "snds-exporter.fullname" . }}
+{{- end }}

--- a/charts/snds-exporter/templates/secrets.yaml
+++ b/charts/snds-exporter/templates/secrets.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.auth.secret.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "snds-exporter.authSecretName" . }}
+  labels:
+    {{- include "snds-exporter.labels" . | nindent 4 }}
+  {{- with .Values.auth.secret.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+type: Opaque
+stringData:
+  {{ .Values.auth.secret.accessTokenKey }}: {{ .Values.auth.secret.accessToken | quote }}
+  {{ .Values.auth.secret.tokenCacheKey }}: {{ .Values.auth.secret.tokenCache | quote }}
+{{- end }}

--- a/charts/snds-exporter/templates/service.yaml
+++ b/charts/snds-exporter/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "snds-exporter.fullname" . }}
+  labels:
+    {{- include "snds-exporter.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "snds-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/snds-exporter/templates/serviceaccount.yaml
+++ b/charts/snds-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "snds-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "snds-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/snds-exporter/templates/servicemonitor.yaml
+++ b/charts/snds-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.serviceMonitor.selfMonitor.enabled }}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "snds-exporter.fullname" $ }}
+  namespace: {{ template "snds-exporter.namespace" $ }}
+  labels:
+    {{- include "snds-exporter.labels" $ | nindent 4 }}
+    {{- if .Values.serviceMonitor.selfMonitor.labels  }}
+    {{- toYaml (.Values.serviceMonitor.selfMonitor.labels) | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - path: {{ .Values.serviceMonitor.selfMonitor.path }}
+      interval: {{ .Values.serviceMonitor.selfMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.selfMonitor.scrapeTimeout }}
+      scheme: http
+
+{{- if .Values.serviceMonitor.selfMonitor.additionalRelabeling }}
+      relabelings:
+{{ toYaml .Values.serviceMonitor.selfMonitor.additionalRelabeling | indent 6 }}
+{{- end }}
+{{- if .Values.serviceMonitor.selfMonitor.additionalMetricsRelabels }}
+      metricRelabelings:
+{{ toYaml .Values.serviceMonitor.selfMonitor.additionalMetricsRelabels | indent 6 }}
+{{- end }}
+  jobLabel: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      {{- include "snds-exporter.selectorLabels" $ | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ template "snds-exporter.namespace" $ }}
+{{- end }}
+{{- end }}

--- a/charts/snds-exporter/values.yaml
+++ b/charts/snds-exporter/values.yaml
@@ -1,0 +1,161 @@
+# Default values for snds-exporter.
+
+# -- Number of snds-exporter pods to run.
+replicaCount: 1
+
+# -- Container image configuration.
+image:
+  # -- Optional image registry prefix.
+  registry: ghcr.io/klicktipp
+  # -- Image repository name.
+  repository: snds-exporter
+  # -- Image tag. When empty, the chart appVersion is used.
+  tag: ""
+  # -- Image pull policy.
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets for the pod.
+imagePullSecrets: []
+# -- Partially override generated resource names.
+nameOverride: ""
+# -- Fully override generated resource names.
+fullnameOverride: ""
+# -- Override the namespace used for namespaced resources.
+namespaceOverride: ""
+
+# -- ServiceAccount configuration.
+serviceAccount:
+  # -- Create a dedicated ServiceAccount.
+  create: true
+  # -- Mount the ServiceAccount token into the pod.
+  automount: true
+  # -- ServiceAccount annotations.
+  annotations: {}
+  # -- Existing ServiceAccount name to use. When empty, a name is generated.
+  name: ""
+
+# -- Extra annotations added to the pod template.
+podAnnotations: {}
+# -- Extra labels added to the pod template.
+podLabels: {}
+
+# -- Pod-level security context.
+podSecurityContext: {}
+
+# -- Container-level security context.
+securityContext: {}
+
+# -- Service configuration.
+service:
+  # -- Kubernetes Service type.
+  type: ClusterIP
+  # -- Metrics port exposed by the Service and container.
+  port: 9100
+
+# -- CPU and memory requests/limits for the container.
+resources: {}
+
+# -- Authentication and token refresh settings.
+auth:
+  # -- Mount path for SNDS token files inside the container.
+  mountPath: /var/run/snds-exporter
+  # -- Secret configuration for access token and cache files.
+  secret:
+    # -- Create the auth Secret from values in this chart.
+    create: true
+    # -- Existing Secret name. When empty, a name is generated.
+    name: ""
+    # -- Secret key containing the access token.
+    accessTokenKey: access-token
+    # -- Secret key containing the token cache file.
+    tokenCacheKey: token-cache.json
+    # -- Annotations added to the generated Secret.
+    annotations: {}
+    # -- Access token content written to the generated Secret.
+    accessToken: ""
+    # -- Token cache JSON content written to the generated Secret.
+    tokenCache: ""
+  # -- Token refresh integration settings.
+  refresh:
+    # -- Enable automatic OAuth token refresh inside the exporter.
+    enabled: true
+    # -- Refresh the token this many seconds before expiry.
+    beforeSeconds: 600
+    # -- Kubernetes Secret patch settings used after token refresh.
+    patchKubernetesSecret:
+      # -- Allow the exporter to patch the Secret after refreshing tokens.
+      enabled: true
+      # -- Secret name to patch. Defaults to the auth Secret name.
+      secretName: ""
+      # -- Secret namespace to patch. Defaults to the release namespace.
+      secretNamespace: ""
+      # -- Secret key updated with the refreshed access token.
+      accessTokenKey: access-token
+      # -- Secret key updated with the refreshed token cache content.
+      tokenCacheKey: token-cache.json
+
+# -- snds-exporter runtime configuration.
+exporter:
+  # -- SNDS REST API endpoint returning report data.
+  restApiUrl: https://substrate.office.com/ip-domain-management-snds/api/report/data
+  # -- SNDS status API endpoint returning IP status information.
+  statusApiUrl: https://substrate.office.com/ip-domain-management-snds/api/report/status/ip
+  # -- Number of days requested from the report API.
+  restApiLookbackDays: 3
+  # -- HTTP request timeout in seconds for SNDS API calls.
+  requestTimeout: 10
+  # -- Response cache duration in seconds.
+  cacheSeconds: 300
+  # -- Verify TLS certificates for outbound HTTPS requests.
+  verifyTls: true
+  # -- Custom User-Agent header sent to SNDS APIs.
+  userAgent: kt-snds-exporter/1.0
+  # -- Log unexpected API responses for debugging.
+  debugUnknownResponses: false
+
+# -- Additional environment variables appended to the container.
+extraEnv: []
+# -- Additional volume mounts appended to the container.
+extraVolumeMounts: []
+# -- Additional volumes appended to the pod.
+extraVolumes: []
+
+# -- Prometheus Operator ServiceMonitor configuration.
+serviceMonitor:
+  # -- Self-monitoring configuration for the exporter Service.
+  selfMonitor:
+    # -- Create a ServiceMonitor when the CRD is available.
+    enabled: true
+    # -- Metrics path scraped by Prometheus.
+    path: /metrics
+    # -- Extra metric relabeling rules for scraped metrics.
+    additionalMetricsRelabels: {}
+    # -- Extra target relabeling rules for the ServiceMonitor endpoint.
+    additionalRelabeling:
+      - action: labeldrop
+        regex: (instance|pod)
+    # -- Additional labels added to the ServiceMonitor.
+    labels: {}
+    # -- Prometheus scrape interval.
+    interval: 300s
+    # -- Prometheus scrape timeout.
+    scrapeTimeout: 60s
+
+# -- Liveness probe configuration for the exporter container.
+livenessProbe:
+  httpGet:
+    path: /livez
+    port: http
+
+# -- Readiness probe configuration for the exporter container.
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+
+# -- Node selector for pod scheduling.
+nodeSelector: {}
+# -- Tolerations for pod scheduling.
+tolerations: []
+# -- Affinity rules for pod scheduling.
+affinity: {}

--- a/charts/snds-exporter/values.yaml
+++ b/charts/snds-exporter/values.yaml
@@ -105,7 +105,7 @@ exporter:
   # -- HTTP request timeout in seconds for SNDS API calls.
   requestTimeout: 10
   # -- Response cache duration in seconds.
-  cacheSeconds: 300
+  cacheSeconds: 3600
   # -- Verify TLS certificates for outbound HTTPS requests.
   verifyTls: true
   # -- Custom User-Agent header sent to SNDS APIs.
@@ -137,7 +137,7 @@ serviceMonitor:
     # -- Additional labels added to the ServiceMonitor.
     labels: {}
     # -- Prometheus scrape interval.
-    interval: 300s
+    interval: 1h
     # -- Prometheus scrape timeout.
     scrapeTimeout: 60s
 


### PR DESCRIPTION
Includes Chart.yaml and default values
Adds deployment, service, secret, RBAC, and ServiceMonitor Provides README with authentication and usage instructions Supports token refresh and optional secret patching