### PR TITLE
Add Helm chart for csa-exporter

### DIFF
--- a/charts/csa-exporter/.helmignore
+++ b/charts/csa-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/csa-exporter/Chart.yaml
+++ b/charts/csa-exporter/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: csa-exporter
+description: A Helm chart for Kubernetes to scrape the CSA stats API.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - csa
+  - exporter
+  - prometheus
+home: https://github.com/klicktipp/helm-charts
+sources:
+  - https://github.com/klicktipp/helm-charts
+maintainers:
+  - name: vquie
+    url: https://github.com/vquie

--- a/charts/csa-exporter/Chart.yaml
+++ b/charts/csa-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: csa-exporter
 description: A Helm chart for Kubernetes to scrape the CSA stats API.
 type: application
 version: 0.1.0
-appVersion: "0.1.0"
+appVersion: "0.2.0"
 keywords:
   - csa
   - exporter

--- a/charts/csa-exporter/README.md
+++ b/charts/csa-exporter/README.md
@@ -1,0 +1,104 @@
+# csa-exporter
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes to scrape the CSA stats API.
+
+**Homepage:** <https://github.com/klicktipp/helm-charts>
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| vquie |  | <https://github.com/vquie> |
+## Source Code
+
+* <https://github.com/klicktipp/helm-charts>
+
+## Authentication
+
+The chart supports two authentication modes for the CSA API:
+
+- Token-based auth with `CSA_API_TOKEN`
+- Key-pair auth with `CSA_API_ID` and `CSA_API_SECRET`
+
+The recommended production setup is to provide an existing Kubernetes Secret with the required keys and set `auth.existingSecretName`.
+
+If you want the chart to create the Secret, set `auth.createSecret=true` and provide either:
+
+- `auth.token` together with `auth.secretKeys.token`
+- `auth.id` and `auth.secret` together with `auth.secretKeys.id` and `auth.secretKeys.secret`
+
+When both auth variants are configured, token auth takes precedence.
+
+## Runtime Configuration
+
+The chart exposes optional runtime overrides through `env.*` values:
+
+- `env.apiUrl` overrides the default CSA API endpoint used by the container image
+- `env.apiTimeout` sets the outbound API timeout
+- `env.logLevel` adjusts application logging
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| replicaCount | int | `1` | Number of csa-exporter pods to run. |
+| image | object | `{"digest":"","pullPolicy":"IfNotPresent","registry":"ghcr.io","repository":"klicktipp/csa-exporter","tag":""}` | Container image configuration. |
+| image.registry | string | `"ghcr.io"` | Optional image registry prefix. |
+| image.repository | string | `"klicktipp/csa-exporter"` | Image repository name. |
+| image.tag | string | `""` | Image tag. When empty, the chart appVersion is used. |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
+| image.digest | string | `""` | Optional image digest overriding the tag-based reference. |
+| imagePullSecrets | list | `[]` | Image pull secrets for the pod. |
+| nameOverride | string | `""` | Partially override generated resource names. |
+| fullnameOverride | string | `""` | Fully override generated resource names. |
+| namespaceOverride | string | `""` | Override the namespace used for namespaced resources. |
+| serviceAccount | object | `{"annotations":{},"automount":true,"create":true,"name":""}` | ServiceAccount configuration. |
+| serviceAccount.create | bool | `true` | Create a dedicated ServiceAccount. |
+| serviceAccount.automount | bool | `true` | Mount the ServiceAccount token into the pod. |
+| serviceAccount.annotations | object | `{}` | ServiceAccount annotations. |
+| serviceAccount.name | string | `""` | Existing ServiceAccount name to use. When empty, a name is generated. |
+| podAnnotations | object | `{}` | Extra annotations added to the pod template. |
+| podLabels | object | `{}` | Extra labels added to the pod template. |
+| podSecurityContext | object | `{}` | Pod-level security context. |
+| securityContext | object | `{}` | Container-level security context. |
+| service | object | `{"port":9100,"type":"ClusterIP"}` | Service configuration. |
+| service.type | string | `"ClusterIP"` | Kubernetes Service type. |
+| service.port | int | `9100` | Metrics port exposed by the Service and container. |
+| resources | object | `{}` | CPU and memory requests/limits for the container. |
+| auth | object | `{"createSecret":false,"existingSecretName":"","id":"","secret":"","secretKeys":{"id":"","secret":"","token":"csa-api-token"},"token":""}` | Authentication settings for the CSA API. |
+| auth.createSecret | bool | `false` | Create a Secret from values in this chart instead of referencing an existing one. |
+| auth.existingSecretName | string | `""` | Existing Secret name containing either token auth or id/secret auth keys. |
+| auth.secretKeys | object | `{"id":"","secret":"","token":"csa-api-token"}` | Secret keys used to read credentials from the Secret. Token auth takes precedence. |
+| auth.secretKeys.token | string | `"csa-api-token"` | Secret key containing the CSA API token. |
+| auth.secretKeys.id | string | `""` | Secret key containing the CSA API client ID. |
+| auth.secretKeys.secret | string | `""` | Secret key containing the CSA API client secret. |
+| auth.token | string | `""` | Token value written to the generated Secret. Takes precedence over id/secret auth. |
+| auth.id | string | `""` | Client ID value written to the generated Secret when using key-pair auth. |
+| auth.secret | string | `""` | Client secret value written to the generated Secret when using key-pair auth. |
+| env | object | `{"apiTimeout":"","apiUrl":"","logLevel":""}` | Optional runtime environment overrides passed to the container. |
+| env.apiUrl | string | `""` | Override the CSA API base URL expected by the exporter image. |
+| env.apiTimeout | string | `""` | Override the outbound CSA API timeout value. |
+| env.logLevel | string | `""` | Override the exporter log level. |
+| extraEnv | list | `[]` | Additional environment variables appended to the container. |
+| extraVolumeMounts | list | `[]` | Additional volume mounts appended to the container. |
+| extraVolumes | list | `[]` | Additional volumes appended to the pod. |
+| serviceMonitor | object | `{"selfMonitor":{"additionalMetricsRelabels":{},"additionalRelabeling":[{"action":"labeldrop","regex":"(instance|pod)"}],"enabled":true,"interval":"300s","labels":{},"path":"/metrics","scrapeTimeout":"60s"}}` | Prometheus Operator ServiceMonitor configuration. |
+| serviceMonitor.selfMonitor | object | `{"additionalMetricsRelabels":{},"additionalRelabeling":[{"action":"labeldrop","regex":"(instance|pod)"}],"enabled":true,"interval":"300s","labels":{},"path":"/metrics","scrapeTimeout":"60s"}` | Self-monitoring configuration for the exporter Service. |
+| serviceMonitor.selfMonitor.enabled | bool | `true` | Create a ServiceMonitor when the CRD is available. |
+| serviceMonitor.selfMonitor.path | string | `"/metrics"` | Metrics path scraped by Prometheus. |
+| serviceMonitor.selfMonitor.additionalMetricsRelabels | object | `{}` | Extra metric relabeling rules for scraped metrics. |
+| serviceMonitor.selfMonitor.additionalRelabeling | list | `[{"action":"labeldrop","regex":"(instance|pod)"}]` | Extra target relabeling rules for the ServiceMonitor endpoint. |
+| serviceMonitor.selfMonitor.additionalRelabeling[0].regex | string | `"(instance|pod)"` | Regex used by the default relabeling rule. |
+| serviceMonitor.selfMonitor.labels | object | `{}` | Additional labels added to the ServiceMonitor. |
+| serviceMonitor.selfMonitor.interval | string | `"300s"` | Prometheus scrape interval. |
+| serviceMonitor.selfMonitor.scrapeTimeout | string | `"60s"` | Prometheus scrape timeout. |
+| livenessProbe | object | `{"httpGet":{"path":"/livez","port":"http"}}` | Liveness probe configuration for the exporter container. |
+| livenessProbe.httpGet.path | string | `"/livez"` | HTTP path used by the liveness probe. |
+| livenessProbe.httpGet.port | string | `"http"` | Named port used by the liveness probe. |
+| readinessProbe | object | `{"httpGet":{"path":"/healthz","port":"http"}}` | Readiness probe configuration for the exporter container. |
+| readinessProbe.httpGet.path | string | `"/healthz"` | HTTP path used by the readiness probe. |
+| readinessProbe.httpGet.port | string | `"http"` | Named port used by the readiness probe. |
+| nodeSelector | object | `{}` | Node selector for pod scheduling. |
+| tolerations | list | `[]` | Tolerations for pod scheduling. |
+| affinity | object | `{}` | Affinity rules for pod scheduling. |

--- a/charts/csa-exporter/README.md
+++ b/charts/csa-exporter/README.md
@@ -1,6 +1,6 @@
 # csa-exporter
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes to scrape the CSA stats API.
 

--- a/charts/csa-exporter/README.md.gotmpl
+++ b/charts/csa-exporter/README.md.gotmpl
@@ -1,0 +1,37 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+{{ template "chart.maintainersSection" . }}
+{{ template "chart.sourcesSection" . }}
+
+## Authentication
+
+The chart supports two authentication modes for the CSA API:
+
+- Token-based auth with `CSA_API_TOKEN`
+- Key-pair auth with `CSA_API_ID` and `CSA_API_SECRET`
+
+The recommended production setup is to provide an existing Kubernetes Secret with the required keys and set `auth.existingSecretName`.
+
+If you want the chart to create the Secret, set `auth.createSecret=true` and provide either:
+
+- `auth.token` together with `auth.secretKeys.token`
+- `auth.id` and `auth.secret` together with `auth.secretKeys.id` and `auth.secretKeys.secret`
+
+When both auth variants are configured, token auth takes precedence.
+
+## Runtime Configuration
+
+The chart exposes optional runtime overrides through `env.*` values:
+
+- `env.apiUrl` overrides the default CSA API endpoint used by the container image
+- `env.apiTimeout` sets the outbound API timeout
+- `env.logLevel` adjusts application logging
+
+{{ template "chart.valuesSection" . }}

--- a/charts/csa-exporter/templates/_helpers.tpl
+++ b/charts/csa-exporter/templates/_helpers.tpl
@@ -1,0 +1,94 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "csa-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "csa-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "csa-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "csa-exporter.labels" -}}
+helm.sh/chart: {{ include "csa-exporter.chart" . }}
+{{ include "csa-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "csa-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "csa-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "csa-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "csa-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "csa-exporter.secretName" -}}
+{{- if .Values.auth.existingSecretName }}
+{{- .Values.auth.existingSecretName }}
+{{- else }}
+{{- printf "%s-auth" (include "csa-exporter.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{- define "csa-exporter.useTokenAuth" -}}
+{{- if .Values.auth.token -}}
+true
+{{- else if and .Values.auth.secretKeys.token (not .Values.auth.id) (not .Values.auth.secret) (not .Values.auth.secretKeys.id) (not .Values.auth.secretKeys.secret) -}}
+true
+{{- end }}
+{{- end }}
+
+{{- define "csa-exporter.usePartsAuth" -}}
+{{- if and (not .Values.auth.token) .Values.auth.id .Values.auth.secret -}}
+true
+{{- else if and (not .Values.auth.token) .Values.auth.secretKeys.id .Values.auth.secretKeys.secret -}}
+true
+{{- end }}
+{{- end }}
+
+{{- define "csa-exporter.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/csa-exporter/templates/deployment.yaml
+++ b/charts/csa-exporter/templates/deployment.yaml
@@ -1,0 +1,104 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "csa-exporter.fullname" . }}
+  labels:
+    {{- include "csa-exporter.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "csa-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "csa-exporter.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "csa-exporter.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ if .Values.image.registry }}{{ .Values.image.registry }}/{{ end }}{{ .Values.image.repository }}{{ if .Values.image.digest }}@{{ .Values.image.digest }}{{ else }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ end }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if or .Values.auth.createSecret .Values.auth.existingSecretName .Values.env.apiUrl .Values.env.apiTimeout .Values.env.logLevel .Values.extraEnv }}
+          env:
+            {{- if or .Values.auth.createSecret .Values.auth.existingSecretName }}
+            {{- if include "csa-exporter.useTokenAuth" . }}
+            - name: CSA_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "csa-exporter.secretName" . }}
+                  key: {{ .Values.auth.secretKeys.token }}
+            {{- else if include "csa-exporter.usePartsAuth" . }}
+            - name: CSA_API_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "csa-exporter.secretName" . }}
+                  key: {{ .Values.auth.secretKeys.id }}
+            - name: CSA_API_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "csa-exporter.secretName" . }}
+                  key: {{ .Values.auth.secretKeys.secret }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.env.apiUrl }}
+            - name: CSA_API_URL
+              value: {{ .Values.env.apiUrl | quote }}
+            {{- end }}
+            {{- if .Values.env.apiTimeout }}
+            - name: CSA_API_TIMEOUT
+              value: {{ .Values.env.apiTimeout | quote }}
+            {{- end }}
+            {{- if .Values.env.logLevel }}
+            - name: LOG_LEVEL
+              value: {{ .Values.env.logLevel | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+      {{- with .Values.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/csa-exporter/templates/secrets.yaml
+++ b/charts/csa-exporter/templates/secrets.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.auth.createSecret (not .Values.auth.existingSecretName) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "csa-exporter.secretName" . }}
+  labels:
+    {{- include "csa-exporter.labels" . | nindent 4 }}
+type: Opaque
+{{- if include "csa-exporter.useTokenAuth" . }}
+stringData:
+  {{- if .Values.auth.token }}
+  {{ .Values.auth.secretKeys.token }}: {{ .Values.auth.token | quote }}
+  {{- end }}
+{{- else if include "csa-exporter.usePartsAuth" . }}
+stringData:
+  {{- if .Values.auth.id }}
+  {{ .Values.auth.secretKeys.id }}: {{ .Values.auth.id | quote }}
+  {{- end }}
+  {{- if .Values.auth.secret }}
+  {{ .Values.auth.secretKeys.secret }}: {{ .Values.auth.secret | quote }}
+  {{- end }}
+{{- else }}
+stringData: {}
+{{- end }}
+{{- end }}

--- a/charts/csa-exporter/templates/service.yaml
+++ b/charts/csa-exporter/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "csa-exporter.fullname" . }}
+  labels:
+    {{- include "csa-exporter.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "csa-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/csa-exporter/templates/serviceaccount.yaml
+++ b/charts/csa-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "csa-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "csa-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/csa-exporter/templates/servicemonitor.yaml
+++ b/charts/csa-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.serviceMonitor.selfMonitor.enabled }}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "csa-exporter.fullname" $ }}
+  namespace: {{ template "csa-exporter.namespace" $ }}
+  labels:
+    {{- include "csa-exporter.labels" $ | nindent 4 }}
+    {{- if .Values.serviceMonitor.selfMonitor.labels  }}
+    {{- toYaml (.Values.serviceMonitor.selfMonitor.labels) | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - path: {{ .Values.serviceMonitor.selfMonitor.path }}
+      port: http
+      interval: {{ .Values.serviceMonitor.selfMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.selfMonitor.scrapeTimeout }}
+      scheme: http
+{{- if .Values.serviceMonitor.selfMonitor.additionalRelabeling }}
+      relabelings:
+{{ toYaml .Values.serviceMonitor.selfMonitor.additionalRelabeling | indent 6 }}
+{{- end }}
+{{- if .Values.serviceMonitor.selfMonitor.additionalMetricsRelabels }}
+      metricRelabelings:
+{{ toYaml .Values.serviceMonitor.selfMonitor.additionalMetricsRelabels | indent 6 }}
+{{- end }}
+  jobLabel: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      {{- include "csa-exporter.selectorLabels" $ | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ template "csa-exporter.namespace" $ }}
+{{- end }}
+{{- end }}

--- a/charts/csa-exporter/values.yaml
+++ b/charts/csa-exporter/values.yaml
@@ -1,0 +1,140 @@
+# Default values for csa-exporter.
+
+# -- Number of csa-exporter pods to run.
+replicaCount: 1
+
+# -- Container image configuration.
+image:
+  # -- Optional image registry prefix.
+  registry: ghcr.io
+  # -- Image repository name.
+  repository: klicktipp/csa-exporter
+  # -- Image tag. When empty, the chart appVersion is used.
+  tag: ""
+  # -- Image pull policy.
+  pullPolicy: IfNotPresent
+  # -- Optional image digest overriding the tag-based reference.
+  digest: ""
+
+# -- Image pull secrets for the pod.
+imagePullSecrets: []
+# -- Partially override generated resource names.
+nameOverride: ""
+# -- Fully override generated resource names.
+fullnameOverride: ""
+# -- Override the namespace used for namespaced resources.
+namespaceOverride: ""
+
+# -- ServiceAccount configuration.
+serviceAccount:
+  # -- Create a dedicated ServiceAccount.
+  create: true
+  # -- Mount the ServiceAccount token into the pod.
+  automount: true
+  # -- ServiceAccount annotations.
+  annotations: {}
+  # -- Existing ServiceAccount name to use. When empty, a name is generated.
+  name: ""
+
+# -- Extra annotations added to the pod template.
+podAnnotations: {}
+# -- Extra labels added to the pod template.
+podLabels: {}
+
+# -- Pod-level security context.
+podSecurityContext: {}
+# -- Container-level security context.
+securityContext: {}
+
+# -- Service configuration.
+service:
+  # -- Kubernetes Service type.
+  type: ClusterIP
+  # -- Metrics port exposed by the Service and container.
+  port: 9100
+
+# -- CPU and memory requests/limits for the container.
+resources: {}
+
+# -- Authentication settings for the CSA API.
+auth:
+  # -- Create a Secret from values in this chart instead of referencing an existing one.
+  createSecret: false
+  # -- Existing Secret name containing either token auth or id/secret auth keys.
+  existingSecretName: ""
+  # -- Secret keys used to read credentials from the Secret. Token auth takes precedence.
+  secretKeys:
+    # -- Secret key containing the CSA API token.
+    token: csa-api-token
+    # -- Secret key containing the CSA API client ID.
+    id: ""
+    # -- Secret key containing the CSA API client secret.
+    secret: ""
+  # -- Token value written to the generated Secret. Takes precedence over id/secret auth.
+  token: ""
+  # -- Client ID value written to the generated Secret when using key-pair auth.
+  id: ""
+  # -- Client secret value written to the generated Secret when using key-pair auth.
+  secret: ""
+
+# -- Optional runtime environment overrides passed to the container.
+env:
+  # -- Override the CSA API base URL expected by the exporter image.
+  apiUrl: ""
+  # -- Override the outbound CSA API timeout value.
+  apiTimeout: ""
+  # -- Override the exporter log level.
+  logLevel: ""
+
+# -- Additional environment variables appended to the container.
+extraEnv: []
+# -- Additional volume mounts appended to the container.
+extraVolumeMounts: []
+# -- Additional volumes appended to the pod.
+extraVolumes: []
+
+# -- Prometheus Operator ServiceMonitor configuration.
+serviceMonitor:
+  # -- Self-monitoring configuration for the exporter Service.
+  selfMonitor:
+    # -- Create a ServiceMonitor when the CRD is available.
+    enabled: true
+    # -- Metrics path scraped by Prometheus.
+    path: /metrics
+    # -- Extra metric relabeling rules for scraped metrics.
+    additionalMetricsRelabels: {}
+    # -- Extra target relabeling rules for the ServiceMonitor endpoint.
+    additionalRelabeling:
+      - action: labeldrop
+        # -- Regex used by the default relabeling rule.
+        regex: (instance|pod)
+    # -- Additional labels added to the ServiceMonitor.
+    labels: {}
+    # -- Prometheus scrape interval.
+    interval: 300s
+    # -- Prometheus scrape timeout.
+    scrapeTimeout: 60s
+
+# -- Liveness probe configuration for the exporter container.
+livenessProbe:
+  httpGet:
+    # -- HTTP path used by the liveness probe.
+    path: /livez
+    # -- Named port used by the liveness probe.
+    port: http
+# -- Readiness probe configuration for the exporter container.
+readinessProbe:
+  httpGet:
+    # -- HTTP path used by the readiness probe.
+    path: /healthz
+    # -- Named port used by the readiness probe.
+    port: http
+
+# -- Node selector for pod scheduling.
+nodeSelector: {}
+
+# -- Tolerations for pod scheduling.
+tolerations: []
+
+# -- Affinity rules for pod scheduling.
+affinity: {}


### PR DESCRIPTION
Includes Deployment, Service, and ServiceAccount
Supports token and key-pair authentication via Secrets Adds ServiceMonitor for Prometheus scraping
Provides runtime overrides and customizable probes Includes README with values and configuration