### PR TITLE
[cronjobs] Fix PV name collision for long namespace names

### DIFF
--- a/charts/cronjobs/Chart.yaml
+++ b/charts/cronjobs/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: cronjobs
 description: A generic helm cronjob chart for kubernetes
 type: application
-version: 1.7.0
+version: 1.7.1
 appVersion: latest
 home: https://github.com/klicktipp/helm-charts
 keywords:

--- a/charts/cronjobs/README.md
+++ b/charts/cronjobs/README.md
@@ -1,6 +1,6 @@
 # cronjobs
 
-![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 1.7.1](https://img.shields.io/badge/Version-1.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 A generic helm cronjob chart for kubernetes
 

--- a/charts/cronjobs/templates/_helpers.tpl
+++ b/charts/cronjobs/templates/_helpers.tpl
@@ -90,14 +90,21 @@ reject the update because the PV's volume source is immutable after creation.
 */}}
 {{- define "com.klicktipp.slugify-volume-name" -}}
 {{- if and (kindIs "slice" .) (gt (len .) 1) -}}
-{{-   $last   := last    . | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
-{{-   $prefix := join "-" (initial .) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
-{{-   $max    := int (sub 63 (add 1 (len $last))) -}}
-{{-   if lt $max 1 }}{{- $max = 1 }}{{- end -}}
-{{-   printf "%s-%s" ($prefix | trunc $max | trimSuffix "-") $last | trimSuffix "-" -}}
+{{-   $last   := last . | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
+{{-   if ge (len $last) 63 -}}
+{{-     $last | trunc 63 | trimSuffix "-" | trimPrefix "-" -}}
+{{-   else -}}
+{{-     $prefix := join "-" (initial .) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
+{{-     $max    := int (sub 63 (add 1 (len $last))) -}}
+{{-     $p      := $prefix | trunc $max | trimSuffix "-" | trimPrefix "-" -}}
+{{-     if eq $p "" -}}
+{{-       $last -}}
+{{-     else -}}
+{{-       printf "%s-%s" $p $last | trimSuffix "-" -}}
+{{-     end -}}
+{{-   end -}}
 {{- else -}}
 {{-   (join "-" .) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/cronjobs/templates/_helpers.tpl
+++ b/charts/cronjobs/templates/_helpers.tpl
@@ -106,6 +106,7 @@ reject the update because the PV's volume source is immutable after creation.
 {{- else -}}
 {{-   (join "-" .) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+{{- end -}}
 
 {{/*
 Generate deterministic startup delay seconds from seed parts.

--- a/charts/cronjobs/templates/_helpers.tpl
+++ b/charts/cronjobs/templates/_helpers.tpl
@@ -75,11 +75,23 @@ Return the fully qualified startup jitter image reference.
 
 {{/*
 Given a list of strings, concatenate all of them with a dash ("-")
-and slugify the string to be DNS name compatible
+and slugify the string to be DNS name compatible.
+
+When given a list of 2+ elements, the last element (e.g. an EFS access point ID)
+is always preserved in full; only the prefix is truncated if the total exceeds 63
+chars. This prevents long namespaces from silently collapsing all access-point
+suffixes into the same PV name.
 */}}
 {{- define "com.klicktipp.slugify-volume-name" -}}
-{{- $r := (join "-" .) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trunc 63 | trimSuffix "-" }}
-{{- $r }}
+{{- if and (kindIs "slice" .) (gt (len .) 1) -}}
+{{-   $last   := last    . | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
+{{-   $prefix := join "-" (initial .) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
+{{-   $max    := int (sub 63 (add 1 (len $last))) -}}
+{{-   if lt $max 1 }}{{- $max = 1 }}{{- end -}}
+{{-   printf "%s-%s" ($prefix | trunc $max | trimSuffix "-") $last | trimSuffix "-" -}}
+{{- else -}}
+{{-   (join "-" .) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/cronjobs/templates/_helpers.tpl
+++ b/charts/cronjobs/templates/_helpers.tpl
@@ -74,13 +74,19 @@ Return the fully qualified startup jitter image reference.
 {{- end -}}
 
 {{/*
-Given a list of strings, concatenate all of them with a dash ("-")
-and slugify the string to be DNS name compatible.
+Joins a list of strings with "-" and makes the result safe for use as a
+Kubernetes resource name (lowercase, no special chars, max 63 chars).
 
-When given a list of 2+ elements, the last element (e.g. an EFS access point ID)
-is always preserved in full; only the prefix is truncated if the total exceeds 63
-chars. This prevents long namespaces from silently collapsing all access-point
-suffixes into the same PV name.
+The last element is always kept in full — it is the unique part (e.g. an EFS
+access point ID like "0e702cdce44153d31"). If the combined string would exceed
+63 chars, the prefix (everything before the last element) is shortened from the
+right to make room. This way two different access points for the same job always
+get two different PV names, even in namespaces with long names.
+
+Without this fix, the entire string was cut off at 63 chars from the right,
+which silently dropped the access point ID for long namespace names, making
+every access point of a job produce the same PV name — causing Kubernetes to
+reject the update because the PV's volume source is immutable after creation.
 */}}
 {{- define "com.klicktipp.slugify-volume-name" -}}
 {{- if and (kindIs "slice" .) (gt (len .) 1) -}}


### PR DESCRIPTION
## Description

When a Kubernetes namespace name is long, PersistentVolume names for cronjobs with multiple EFS mounts were being silently truncated to the same 63-character string — stripping the unique EFS access point ID from the end.

This meant every EFS mount for the same job tried to create a PV with the same name but a different storage target. Kubernetes only accepted the first one; every subsequent deploy then failed with:

`PersistentVolume "..." is invalid: spec.persistentvolumesource: Forbidden: spec.persistentvolumesource is immutable after creation`

## What changed: 

`slugify-volume-name` now truncates the prefix (namespace + job name) rather than the whole string. The last element — the access point ID — is always kept in full. Names are identical to before since they are short enough to never have been truncated.