### PR TITLE
fix(powerdns-recursor): remove stale recordcache assertion from unit test

### DIFF
--- a/charts/powerdns-recursor/tests/powerdns_recursor_test.yaml
+++ b/charts/powerdns-recursor/tests/powerdns_recursor_test.yaml
@@ -41,8 +41,6 @@ tests:
             outgoing:
               source_address:
               - 0.0.0.0
-            recordcache:
-              refresh_on_ttl_perc: 10
             recursor:
               config_dir: /etc/powerdns
               setgid: pdns


### PR DESCRIPTION
## Summary

- PR #159 (pdns-recursor 5.4.1 → 5.4.2) is blocked because the helm-unittest test still asserts `recordcache.refresh_on_ttl_perc: 10` in the default configmap output
- That default was removed from `values.yaml` in the previous release (PR #149 / chart 0.4.7) but the test wasn't updated
- This removes the two stale lines from the test assertion

## Test plan

- [ ] `Run helm-unittest for changed charts` check should pass on PR #159 after this is merged into the renovate branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)