### PR TITLE
chore(renovate): automerge patch updates for powerdns-recursor

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,12 @@
   ],
   "packageRules": [
     {
+      "description": "Automerge patch updates for powerdns-recursor (security fixes)",
+      "matchPackageNames": ["powerdns/pdns-recursor-54"],
+      "automerge": true,
+      "matchUpdateTypes": ["patch"]
+    },
+    {
       "changelogUrl": "https://github.com/n8n-io/n8n",
       "matchPackageNames": [
         "n8nio/n8n",

--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:best-practices"
-  ],
+  "extends": ["config:best-practices"],
   "semanticCommits": "enabled",
-  "ignorePresets": [
-    "docker:pinDigests",
-    ":pinDevDependencies"
-  ],
+  "ignorePresets": ["docker:pinDigests", ":pinDevDependencies"],
   "packageRules": [
     {
       "description": "Automerge patch updates for powerdns-recursor (security fixes)",
@@ -17,10 +12,7 @@
     },
     {
       "changelogUrl": "https://github.com/n8n-io/n8n",
-      "matchPackageNames": [
-        "n8nio/n8n",
-        "n8n"
-      ]
+      "matchPackageNames": ["n8nio/n8n", "n8n"]
     },
     {
       "matchFileNames": ["charts/**"],
@@ -36,9 +28,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)Chart\\.ya?ml$/"
-      ],
+      "managerFilePatterns": ["/(^|/)Chart\\.ya?ml$/"],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s*depName=(?<depName>\\S+)(?:\\s*versioning=(?<versioning>\\S+))?[\\s\\S]*?appVersion\\s*:\\s*\"?(?<currentValue>[^\"\\n\\r]*)\"?"
       ],


### PR DESCRIPTION
## Summary

- Adds a `packageRule` to automerge `patch` updates for `powerdns/pdns-recursor-54`
- Triggered by today's incident where a security fix (5.4.1 → 5.4.2) required manual merging of PR #149
- No schedule set — the existing CI gates (helm-unittest, lint, chart install) are sufficient as a quality barrier

## Related

- Companion MR in k8stipp: [!3481](https://gitlab.com/klicktipp/cloud/k8stipp/-/merge_requests/3481) — automerges the ArgoCD `targetRevision` bump
- Test fix for the failing unittest: [#160](https://github.com/klicktipp/helm-charts/pull/160) — must be merged first so future automerges don't get blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)