### PR TITLE
fix(cronjobs): fix EFS PV/PVC naming collisions for long namespace names

### DIFF
--- a/charts/cronjobs/Chart.yaml
+++ b/charts/cronjobs/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: cronjobs
 description: A generic helm cronjob chart for kubernetes
 type: application
-version: 1.7.1
+version: 2.0.0
 appVersion: latest
 home: https://github.com/klicktipp/helm-charts
 keywords:

--- a/charts/cronjobs/templates/_helpers.tpl
+++ b/charts/cronjobs/templates/_helpers.tpl
@@ -77,30 +77,28 @@ Return the fully qualified startup jitter image reference.
 Joins a list of strings with "-" and makes the result safe for use as a
 Kubernetes resource name (lowercase, no special chars, max 63 chars).
 
-The last element is always kept in full — it is the unique part (e.g. an EFS
-access point ID like "0e702cdce44153d31"). If the combined string would exceed
-63 chars, the prefix (everything before the last element) is shortened from the
-right to make room. This way two different access points for the same job always
-get two different PV names, even in namespaces with long names.
+When the combined string fits within 63 chars it is used as-is — this keeps
+names in long-lived namespaces (staging, prod) stable.
 
-Without this fix, the entire string was cut off at 63 chars from the right,
-which silently dropped the access point ID for long namespace names, making
-every access point of a job produce the same PV name — causing Kubernetes to
-reject the update because the PV's volume source is immutable after creation.
+When the name would exceed 63 chars, the last element (EFS access point ID)
+is replaced with a 6-char sha256 hash of its value. This keeps the infix
+(chart + job name) readable while still uniquely identifying the access point.
 */}}
 {{- define "com.klicktipp.slugify-volume-name" -}}
 {{- if and (kindIs "slice" .) (gt (len .) 1) -}}
 {{-   $last   := last . | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
-{{-   if ge (len $last) 63 -}}
-{{-     $last | trunc 63 | trimSuffix "-" | trimPrefix "-" -}}
+{{-   $prefix := join "-" (initial .) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
+{{-   $full   := printf "%s-%s" $prefix $last -}}
+{{-   if le (len $full) 63 -}}
+{{-     $full -}}
 {{-   else -}}
-{{-     $prefix := join "-" (initial .) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
-{{-     $max    := int (sub 63 (add 1 (len $last))) -}}
+{{-     $suffix := $last | sha256sum | trunc 6 -}}
+{{-     $max    := int (sub 63 (add 1 (len $suffix))) -}}
 {{-     $p      := $prefix | trunc $max | trimSuffix "-" | trimPrefix "-" -}}
 {{-     if eq $p "" -}}
-{{-       $last -}}
+{{-       $suffix -}}
 {{-     else -}}
-{{-       printf "%s-%s" $p $last | trimSuffix "-" -}}
+{{-       printf "%s-%s" $p $suffix -}}
 {{-     end -}}
 {{-   end -}}
 {{- else -}}

--- a/charts/cronjobs/templates/_helpers.tpl
+++ b/charts/cronjobs/templates/_helpers.tpl
@@ -74,35 +74,51 @@ Return the fully qualified startup jitter image reference.
 {{- end -}}
 
 {{/*
-Joins a list of strings with "-" and makes the result safe for use as a
-Kubernetes resource name (lowercase, no special chars, max 63 chars).
-
-When the combined string fits within 63 chars it is used as-is — this keeps
-names in long-lived namespaces (staging, prod) stable.
-
-When the name would exceed 63 chars, the last element (EFS access point ID)
-is replaced with a 6-char sha256 hash of its value. This keeps the infix
-(chart + job name) readable while still uniquely identifying the access point.
+Given a list of strings, concatenate all of them with a dash ("-")
+and slugify the string to be DNS name compatible
 */}}
 {{- define "com.klicktipp.slugify-volume-name" -}}
-{{- if and (kindIs "slice" .) (gt (len .) 1) -}}
-{{-   $last   := last . | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
-{{-   $prefix := join "-" (initial .) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
-{{-   $full   := printf "%s-%s" $prefix $last -}}
-{{-   if le (len $full) 63 -}}
-{{-     $full -}}
+{{- $r := (join "-" .) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trunc 63 | trimSuffix "-" }}
+{{- $r }}
+{{- end -}}
+
+{{/*
+Collision-free PV / PVC names. Accepts the same list as slugify-volume-name:
+  [prefix, infix..., suffix]
+  prefix – first element (namespace for PVs, release name for PVCs); kept as-is
+  infix  – all middle elements; joined and sha256-hashed to 8 hex chars
+  suffix – last element (EFS access-point ID without "fsap-" prefix); kept as-is
+
+Result: prefix-hash(infix)-suffix  (≤ 63 chars)
+
+When the result would exceed 63 chars the prefix is right-truncated to fit;
+any trailing dash introduced by truncation is stripped.
+
+Because the hash covers the full infix and the access-point ID sits verbatim in
+the suffix, names are globally unique even if the same access point is mounted
+more than once or two jobs share the same name prefix.
+
+Enable per release with .Values.slugifyVolumeNamesV2: true.
+*/}}
+{{- define "com.klicktipp.slugify-volume-name-v2" -}}
+{{- $first  := first . | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
+{{- $last   := last  . | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
+{{- $hash   := join "-" (rest (initial .)) | sha256sum | trunc 8 -}}
+{{- $result := printf "%s-%s-%s" $first $hash $last -}}
+{{- if le (len $result) 63 -}}
+{{-   $result -}}
+{{- else -}}
+{{-   $max := int (sub 53 (len $last)) -}}
+{{-   if le $max 0 -}}
+{{-     printf "%s-%s" $hash $last | trunc 63 | trimSuffix "-" -}}
 {{-   else -}}
-{{-     $suffix := $last | sha256sum | trunc 6 -}}
-{{-     $max    := int (sub 63 (add 1 (len $suffix))) -}}
-{{-     $p      := $prefix | trunc $max | trimSuffix "-" | trimPrefix "-" -}}
-{{-     if eq $p "" -}}
-{{-       $suffix -}}
+{{-     $f := $first | trunc $max | trimSuffix "-" | trimPrefix "-" -}}
+{{-     if eq $f "" -}}
+{{-       printf "%s-%s" $hash $last -}}
 {{-     else -}}
-{{-       printf "%s-%s" $p $suffix -}}
+{{-       printf "%s-%s-%s" $f $hash $last -}}
 {{-     end -}}
 {{-   end -}}
-{{- else -}}
-{{-   (join "-" .) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/cronjobs/templates/cronjob.yaml
+++ b/charts/cronjobs/templates/cronjob.yaml
@@ -140,7 +140,8 @@ spec:
                 {{- range $efs_mount := $job.storage.efs.mounts }}
                 {{- range $efs_ap := $efs_mount.access_points }}
                 {{- $EFS_AP_ID_TRIMMED := trimPrefix "fsap-" $efs_ap.id }}
-                {{- $PVC_NAME := include "com.klicktipp.slugify-volume-name" (list $.Release.Name $JOB_NAME_SLUG $EFS_AP_ID_TRIMMED) }}
+                {{- $slugify  := ternary "com.klicktipp.slugify-volume-name-v2" "com.klicktipp.slugify-volume-name" (default false $.Values.slugifyVolumeNamesV2) -}}
+                {{- $PVC_NAME := include $slugify (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
                 - name: {{ $PVC_NAME }}
                   mountPath: {{ required "ERROR: the EFS mount point requires a mount_dest." $efs_ap.mount_dest }}
                 {{- end }} {{/* # end range $efs_ap */}}
@@ -185,7 +186,8 @@ spec:
             {{- range $efs_mount := $job.storage.efs.mounts }}
             {{- range $efs_ap := $efs_mount.access_points }}
             {{- $EFS_AP_ID_TRIMMED := trimPrefix "fsap-" $efs_ap.id }}
-            {{- $PVC_NAME := include "com.klicktipp.slugify-volume-name" (list $.Release.Name $JOB_NAME_SLUG $EFS_AP_ID_TRIMMED) }}
+            {{- $slugify  := ternary "com.klicktipp.slugify-volume-name-v2" "com.klicktipp.slugify-volume-name" (default false $.Values.slugifyVolumeNamesV2) -}}
+            {{- $PVC_NAME := include $slugify (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
             - name: {{ $PVC_NAME }}
               persistentVolumeClaim:
                 claimName: {{ $PVC_NAME }}

--- a/charts/cronjobs/templates/cronjob.yaml
+++ b/charts/cronjobs/templates/cronjob.yaml
@@ -140,7 +140,7 @@ spec:
                 {{- range $efs_mount := $job.storage.efs.mounts }}
                 {{- range $efs_ap := $efs_mount.access_points }}
                 {{- $EFS_AP_ID_TRIMMED := trimPrefix "fsap-" $efs_ap.id }}
-                {{- $PVC_NAME := include "com.klicktipp.slugify-volume-name" (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
+                {{- $PVC_NAME := include "com.klicktipp.slugify-volume-name" (list $.Release.Name $JOB_NAME_SLUG $EFS_AP_ID_TRIMMED) }}
                 - name: {{ $PVC_NAME }}
                   mountPath: {{ required "ERROR: the EFS mount point requires a mount_dest." $efs_ap.mount_dest }}
                 {{- end }} {{/* # end range $efs_ap */}}
@@ -185,7 +185,7 @@ spec:
             {{- range $efs_mount := $job.storage.efs.mounts }}
             {{- range $efs_ap := $efs_mount.access_points }}
             {{- $EFS_AP_ID_TRIMMED := trimPrefix "fsap-" $efs_ap.id }}
-            {{- $PVC_NAME := include "com.klicktipp.slugify-volume-name" (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
+            {{- $PVC_NAME := include "com.klicktipp.slugify-volume-name" (list $.Release.Name $JOB_NAME_SLUG $EFS_AP_ID_TRIMMED) }}
             - name: {{ $PVC_NAME }}
               persistentVolumeClaim:
                 claimName: {{ $PVC_NAME }}

--- a/charts/cronjobs/templates/volumes.yaml
+++ b/charts/cronjobs/templates/volumes.yaml
@@ -5,8 +5,9 @@
 {{- range $efs_mount := $job.storage.efs.mounts }}
 {{- range $efs_ap := $efs_mount.access_points }}
 {{- $EFS_AP_ID_TRIMMED := trimPrefix "fsap-" $efs_ap.id }}
-{{- $PV_NAME := include "com.klicktipp.slugify-volume-name" (list $.Release.Namespace $.Release.Name $JOB_NAME_SLUG $EFS_AP_ID_TRIMMED) }}
-{{- $PVC_NAME := include "com.klicktipp.slugify-volume-name" (list $.Release.Name $JOB_NAME_SLUG $EFS_AP_ID_TRIMMED) }}
+{{- $slugify  := ternary "com.klicktipp.slugify-volume-name-v2" "com.klicktipp.slugify-volume-name" (default false $.Values.slugifyVolumeNamesV2) -}}
+{{- $PV_NAME  := include $slugify (list $.Release.Namespace $.Release.Name $JOB_NAME_SLUG $EFS_AP_ID_TRIMMED) }}
+{{- $PVC_NAME := include $slugify (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
 ---
 apiVersion: v1
 kind: PersistentVolume

--- a/charts/cronjobs/templates/volumes.yaml
+++ b/charts/cronjobs/templates/volumes.yaml
@@ -8,6 +8,8 @@
 {{- $slugify  := ternary "com.klicktipp.slugify-volume-name-v2" "com.klicktipp.slugify-volume-name" (default false $.Values.slugifyVolumeNamesV2) -}}
 {{- $PV_NAME  := include $slugify (list $.Release.Namespace $.Release.Name $JOB_NAME_SLUG $EFS_AP_ID_TRIMMED) }}
 {{- $PVC_NAME := include $slugify (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
+{{- $PV_FULL  := join "-" (list $.Release.Namespace $.Release.Name $JOB_NAME_SLUG $EFS_AP_ID_TRIMMED) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
+{{- $PVC_FULL := join "-" (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
 ---
 apiVersion: v1
 kind: PersistentVolume
@@ -18,6 +20,7 @@ metadata:
     storage.ktsys.cloud/efs_name: {{ $efs_mount.fs_name | quote }}
     storage.ktsys.cloud/efs_ap_id: {{ $efs_ap.id | quote }}
     storage.ktsys.cloud/efs_path: {{ $efs_ap.path | quote }}
+    storage.ktsys.cloud/volume-name-full: {{ $PV_FULL | quote }}
     {{- with $.commonAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -46,6 +49,7 @@ metadata:
     storage.ktsys.cloud/efs_name: {{ $efs_mount.fs_name | quote }}
     storage.ktsys.cloud/efs_ap_id: {{ $efs_ap.id | quote }}
     storage.ktsys.cloud/efs_path: {{ $efs_ap.path | quote }}
+    storage.ktsys.cloud/volume-name-full: {{ $PVC_FULL | quote }}
     {{- with $.commonAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/cronjobs/templates/volumes.yaml
+++ b/charts/cronjobs/templates/volumes.yaml
@@ -6,7 +6,7 @@
 {{- range $efs_ap := $efs_mount.access_points }}
 {{- $EFS_AP_ID_TRIMMED := trimPrefix "fsap-" $efs_ap.id }}
 {{- $PV_NAME := include "com.klicktipp.slugify-volume-name" (list $.Release.Namespace $.Release.Name $JOB_NAME_SLUG $EFS_AP_ID_TRIMMED) }}
-{{- $PVC_NAME := include "com.klicktipp.slugify-volume-name" (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
+{{- $PVC_NAME := include "com.klicktipp.slugify-volume-name" (list $.Release.Name $JOB_NAME_SLUG $EFS_AP_ID_TRIMMED) }}
 ---
 apiVersion: v1
 kind: PersistentVolume

--- a/charts/cronjobs/templates/volumes.yaml
+++ b/charts/cronjobs/templates/volumes.yaml
@@ -15,6 +15,9 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: {{ $PV_NAME }}
+  labels:
+    storage.ktsys.cloud/efs_fs_id: {{ $efs_mount.fs_id | quote }}
+    storage.ktsys.cloud/efs_ap_id: {{ $efs_ap.id | quote }}
   annotations:
     storage.ktsys.cloud/efs_fs_id: {{ $efs_mount.fs_id | quote }}
     storage.ktsys.cloud/efs_name: {{ $efs_mount.fs_name | quote }}
@@ -44,6 +47,9 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ $PVC_NAME }}
+  labels:
+    storage.ktsys.cloud/efs_fs_id: {{ $efs_mount.fs_id | quote }}
+    storage.ktsys.cloud/efs_ap_id: {{ $efs_ap.id | quote }}
   annotations:
     storage.ktsys.cloud/efs_fs_id: {{ $efs_mount.fs_id | quote }}
     storage.ktsys.cloud/efs_name: {{ $efs_mount.fs_name | quote }}

--- a/charts/cronjobs/values.yaml
+++ b/charts/cronjobs/values.yaml
@@ -3,6 +3,13 @@ nameOverride: ""
 # -- Fully override generated resource names.
 fullnameOverride: ""
 
+# -- Use collision-free EFS PV/PVC naming (com.klicktipp.slugify-volume-name-v2).
+# When enabled, PV names are globally unique and PVC names are namespace-unique
+# by hashing the infix (chart + job name) to 8 hex chars while keeping the
+# namespace/release prefix and EFS access-point ID verbatim.
+# Disabled by default to preserve backward compatibility with existing PVs/PVCs.
+slugifyVolumeNamesV2: false
+
 # -- Image pull secrets.
 imagePullSecrets: []
 


### PR DESCRIPTION
Long namespace names (like `e5c65772f4ec9354be9`) caused EFS PersistentVolume and PersistentVolumeClaim names to exceed the 63-char Kubernetes limit. 
The original truncation silently dropped the EFS access point ID suffix, so multiple access points of the same job ended up with identical PV names — Kubernetes rejected updates because PV volume sources are immutable.      
                                                                                                                                                                                                                                                                                                                                                                                                                
What changed:                                                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                                                
- Added com.klicktipp.slugify-volume-name-v2: hashes the infix (release + job name) to 8 hex chars, keeping the namespace prefix and EFS AP ID verbatim. Guarantees globally unique PV names and namespace-unique PVC names.                                                                                                                                                                                  
- New slugifyVolumeNamesV2: false value flag to opt in — disabled by default to preserve backward compatibility with existing PVs/PVCs on staging/prod.                                                                                                                                                                                                                                                       
- Added storage.ktsys.cloud/volume-name-full annotation to PV and PVC with the full pre-hash name, so operators can see what resource is represented.                                                                                                                                                                                                                                                         
- Added storage.ktsys.cloud/efs_fs_id and storage.ktsys.cloud/efs_ap_id as labels for easy kubectl filtering.                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                                                
How to enable for e2e/affected namespaces:                                                                                                                                                                                                                                                                                                                                                                    
```                                                                                                                                                                                                                                                                                                                                 
slugifyVolumeNamesV2: true
```