### PR TITLE
[cronjobs] Fix cronjobs EFS volume naming rollout

### DIFF
--- a/charts/cronjobs/Chart.lock
+++ b/charts/cronjobs/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: klicktipp-common
+  repository: file://../klicktipp-common
+  version: 1.0.2
+digest: sha256:ed4163e72f3b9f0e40df513d90de7104dd81eb0cfb61889e909a584882c001ef
+generated: "2026-06-29T13:48:55.832244701+02:00"

--- a/charts/cronjobs/Chart.yaml
+++ b/charts/cronjobs/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: cronjobs
 description: A generic helm cronjob chart for kubernetes
 type: application
-version: 2.0.0
+version: 2.0.1
 appVersion: latest
 home: https://github.com/klicktipp/helm-charts
 keywords:

--- a/charts/cronjobs/Chart.yaml
+++ b/charts/cronjobs/Chart.yaml
@@ -10,6 +10,10 @@ keywords:
   - cronjob
 sources:
   - https://github.com/klicktipp/helm-charts
+dependencies:
+  - name: klicktipp-common
+    version: 1.0.2
+    repository: file://../klicktipp-common
 annotations:
   artifacthub.io/links: |
     - name: Image source

--- a/charts/cronjobs/README.md
+++ b/charts/cronjobs/README.md
@@ -1,6 +1,6 @@
 # cronjobs
 
-![Version: 1.7.1](https://img.shields.io/badge/Version-1.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 A generic helm cronjob chart for kubernetes
 
@@ -16,6 +16,7 @@ A generic helm cronjob chart for kubernetes
 |-----|------|---------|-------------|
 | nameOverride | string | `""` | Partially override generated resource names. |
 | fullnameOverride | string | `""` | Fully override generated resource names. |
+| slugifyVolumeNamesV2 | bool | `false` | Use collision-free EFS PV/PVC naming (com.klicktipp.slugify-volume-name-v2). When enabled, PV names are globally unique and PVC names are namespace-unique by hashing the infix (chart + job name) to 8 hex chars while keeping the namespace/release prefix and EFS access-point ID verbatim. Disabled by default to preserve backward compatibility with existing PVs/PVCs. |
 | imagePullSecrets | list | `[]` | Image pull secrets. |
 | image | object | `{}` | Default container image settings for all jobs. Individual jobs can override these values. |
 | secrets | object | `{}` | Configure secrets. |

--- a/charts/cronjobs/README.md
+++ b/charts/cronjobs/README.md
@@ -10,6 +10,12 @@ A generic helm cronjob chart for kubernetes
 
 * <https://github.com/klicktipp/helm-charts>
 
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| file://../klicktipp-common | klicktipp-common | 1.0.2 |
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/charts/cronjobs/ci/efs-volume-names.yaml
+++ b/charts/cronjobs/ci/efs-volume-names.yaml
@@ -1,0 +1,16 @@
+image:
+  repository: busybox
+
+jobs:
+  a-very-long-cronjob-name-that-can-collide:
+    schedule: "* * * * *"
+    storage:
+      efs:
+        storageClass: kt-efs-sc
+        mounts:
+          - fs_name: test-efs
+            fs_id: fs-1234567890abcdef0
+            access_points:
+              - path: /very/long/path/that/can/collide
+                mount_dest: /mnt/test
+                id: fsap-0e702cdce44153d31

--- a/charts/cronjobs/templates/configmap.yaml
+++ b/charts/cronjobs/templates/configmap.yaml
@@ -33,7 +33,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ printf "%s-files-%s" (include "cronjobs.fullname" $) $job_name | include "com.klicktipp.slugify-string" }}
+  name: {{ include "com.klicktipp.slugify-string" (list (include "cronjobs.fullname" $) "files" $job_name) }}
   labels:
     {{- include "cronjobs.labels" $ | nindent 4 }}
     {{- with $.Values.commonLabels }}

--- a/charts/cronjobs/templates/configmap.yaml
+++ b/charts/cronjobs/templates/configmap.yaml
@@ -33,7 +33,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "com.klicktipp.slugify-volume-name" (list (include "cronjobs.fullname" $) "files" $job_name) }}
+  name: {{ printf "%s-files-%s" (include "cronjobs.fullname" $) $job_name | include "com.klicktipp.slugify-string" }}
   labels:
     {{- include "cronjobs.labels" $ | nindent 4 }}
     {{- with $.Values.commonLabels }}

--- a/charts/cronjobs/templates/cronjob.yaml
+++ b/charts/cronjobs/templates/cronjob.yaml
@@ -2,7 +2,7 @@
 {{- $service_account_name := include "cronjobs.serviceAccountName" . }}
 {{- range $job_name, $job := .Values.jobs }}
 {{- if $job }}
-{{- $JOB_NAME_SLUG := include "com.klicktipp.slugify-volume-name" $job_name }}
+{{- $JOB_NAME_SLUG := include "com.klicktipp.slugify-string" $job_name }}
 {{- $env := mergeOverwrite dict $.Values.env ($job.env | default dict) }}
 {{- $image := mergeOverwrite dict ($.Values.image | default dict) ($job.image | default dict) }}
 {{- $timezone := $job.timezone | default $.Values.timezone }}
@@ -130,7 +130,7 @@ spec:
                 - name: {{ $key }}
                   valueFrom:
                     secretKeyRef:
-                      name: {{ include "com.klicktipp.slugify-volume-name" (list (include "cronjobs.fullname" $) $job_name "envvars") }}
+                      name: {{ printf "%s-%s-envvars" (include "cronjobs.fullname" $) $job_name | include "com.klicktipp.slugify-string" }}
                       key: {{ $key }}
                 {{- end }}
               resources:
@@ -197,7 +197,7 @@ spec:
             {{- if and (hasKey $job "extraFiles") $job.extraFiles }}
             - name: cronjob-files
               configMap:
-                name: {{ include "com.klicktipp.slugify-volume-name" (list $chart_name "files" $JOB_NAME_SLUG) }}
+                name: {{ printf "%s-files-%s" $chart_name $JOB_NAME_SLUG | include "com.klicktipp.slugify-string" }}
                 items:
                 {{- range $filename, $file := $job.extraFiles }}
                   {{- if $file.enabled }}

--- a/charts/cronjobs/templates/cronjob.yaml
+++ b/charts/cronjobs/templates/cronjob.yaml
@@ -143,6 +143,8 @@ spec:
                 {{- $slugify  := ternary "com.klicktipp.slugify-volume-name-v2" "com.klicktipp.slugify-volume-name" (default false $.Values.slugifyVolumeNamesV2) -}}
                 {{- $PVC_NAME := include $slugify (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
                 - name: {{ $PVC_NAME }}
+                {{- $PVC_NAME_SLUG := include $slugify (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
+                - name: {{ $PVC_NAME_SLUG }}
                   mountPath: {{ required "ERROR: the EFS mount point requires a mount_dest." $efs_ap.mount_dest }}
                 {{- end }} {{/* # end range $efs_ap */}}
                 {{- end }} {{/* # end range $efs_mount */}}
@@ -189,8 +191,10 @@ spec:
             {{- $slugify  := ternary "com.klicktipp.slugify-volume-name-v2" "com.klicktipp.slugify-volume-name" (default false $.Values.slugifyVolumeNamesV2) -}}
             {{- $PVC_NAME := include $slugify (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
             - name: {{ $PVC_NAME }}
+            {{- $PVC_NAME_SLUG := include $slugify (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
+            - name: {{ $PVC_NAME_SLUG }}
               persistentVolumeClaim:
-                claimName: {{ $PVC_NAME }}
+                claimName: {{ $PVC_NAME_SLUG }}
             {{- end }} {{/* # end range $efs_ap */}}
             {{- end }} {{/* # end range $efs_mount */}}
             {{- end }} {{/* # end if storage.efs */}}

--- a/charts/cronjobs/templates/cronjob.yaml
+++ b/charts/cronjobs/templates/cronjob.yaml
@@ -130,7 +130,7 @@ spec:
                 - name: {{ $key }}
                   valueFrom:
                     secretKeyRef:
-                      name: {{ printf "%s-%s-envvars" (include "cronjobs.fullname" $) $job_name | include "com.klicktipp.slugify-string" }}
+                      name: {{ include "com.klicktipp.slugify-string" (list (include "cronjobs.fullname" $) $job_name "envvars") }}
                       key: {{ $key }}
                 {{- end }}
               resources:
@@ -197,7 +197,7 @@ spec:
             {{- if and (hasKey $job "extraFiles") $job.extraFiles }}
             - name: cronjob-files
               configMap:
-                name: {{ printf "%s-files-%s" $chart_name $JOB_NAME_SLUG | include "com.klicktipp.slugify-string" }}
+                name: {{ include "com.klicktipp.slugify-string" (list $chart_name "files" $JOB_NAME_SLUG) }}
                 items:
                 {{- range $filename, $file := $job.extraFiles }}
                   {{- if $file.enabled }}

--- a/charts/cronjobs/templates/cronjob.yaml
+++ b/charts/cronjobs/templates/cronjob.yaml
@@ -140,9 +140,7 @@ spec:
                 {{- range $efs_mount := $job.storage.efs.mounts }}
                 {{- range $efs_ap := $efs_mount.access_points }}
                 {{- $EFS_AP_ID_TRIMMED := trimPrefix "fsap-" $efs_ap.id }}
-                {{- $slugify  := ternary "com.klicktipp.slugify-volume-name-v2" "com.klicktipp.slugify-volume-name" (default false $.Values.slugifyVolumeNamesV2) -}}
-                {{- $PVC_NAME := include $slugify (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
-                - name: {{ $PVC_NAME }}
+                {{- $slugify  := ternary "com.klicktipp.slugify-volume-name-v2" "com.klicktipp.slugify-volume-name" $.Values.slugifyVolumeNamesV2 -}}
                 {{- $PVC_NAME_SLUG := include $slugify (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
                 - name: {{ $PVC_NAME_SLUG }}
                   mountPath: {{ required "ERROR: the EFS mount point requires a mount_dest." $efs_ap.mount_dest }}
@@ -188,9 +186,7 @@ spec:
             {{- range $efs_mount := $job.storage.efs.mounts }}
             {{- range $efs_ap := $efs_mount.access_points }}
             {{- $EFS_AP_ID_TRIMMED := trimPrefix "fsap-" $efs_ap.id }}
-            {{- $slugify  := ternary "com.klicktipp.slugify-volume-name-v2" "com.klicktipp.slugify-volume-name" (default false $.Values.slugifyVolumeNamesV2) -}}
-            {{- $PVC_NAME := include $slugify (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
-            - name: {{ $PVC_NAME }}
+            {{- $slugify  := ternary "com.klicktipp.slugify-volume-name-v2" "com.klicktipp.slugify-volume-name" $.Values.slugifyVolumeNamesV2 -}}
             {{- $PVC_NAME_SLUG := include $slugify (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
             - name: {{ $PVC_NAME_SLUG }}
               persistentVolumeClaim:

--- a/charts/cronjobs/templates/cronjob.yaml
+++ b/charts/cronjobs/templates/cronjob.yaml
@@ -140,7 +140,7 @@ spec:
                 {{- range $efs_mount := $job.storage.efs.mounts }}
                 {{- range $efs_ap := $efs_mount.access_points }}
                 {{- $EFS_AP_ID_TRIMMED := trimPrefix "fsap-" $efs_ap.id }}
-                {{- $slugify  := ternary "com.klicktipp.slugify-volume-name-v2" "com.klicktipp.slugify-volume-name" $.Values.slugifyVolumeNamesV2 -}}
+                {{- $slugify  := ternary "com.klicktipp.slugify-volume-name-v2" "com.klicktipp.slugify-volume-name" $.Values.slugifyVolumeNamesV2 }}
                 {{- $PVC_NAME_SLUG := include $slugify (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
                 - name: {{ $PVC_NAME_SLUG }}
                   mountPath: {{ required "ERROR: the EFS mount point requires a mount_dest." $efs_ap.mount_dest }}
@@ -186,7 +186,7 @@ spec:
             {{- range $efs_mount := $job.storage.efs.mounts }}
             {{- range $efs_ap := $efs_mount.access_points }}
             {{- $EFS_AP_ID_TRIMMED := trimPrefix "fsap-" $efs_ap.id }}
-            {{- $slugify  := ternary "com.klicktipp.slugify-volume-name-v2" "com.klicktipp.slugify-volume-name" $.Values.slugifyVolumeNamesV2 -}}
+            {{- $slugify  := ternary "com.klicktipp.slugify-volume-name-v2" "com.klicktipp.slugify-volume-name" $.Values.slugifyVolumeNamesV2 }}
             {{- $PVC_NAME_SLUG := include $slugify (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
             - name: {{ $PVC_NAME_SLUG }}
               persistentVolumeClaim:

--- a/charts/cronjobs/templates/secrets.yaml
+++ b/charts/cronjobs/templates/secrets.yaml
@@ -52,7 +52,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "com.klicktipp.slugify-volume-name" (list (include "cronjobs.fullname" $) $job_name "envvars") }}
+  name: {{ printf "%s-%s-envvars" (include "cronjobs.fullname" $) $job_name | include "com.klicktipp.slugify-string" }}
   labels:
     {{- include "cronjobs.labels" $ | nindent 4 }}
     {{- with $.Values.commonLabels }}

--- a/charts/cronjobs/templates/secrets.yaml
+++ b/charts/cronjobs/templates/secrets.yaml
@@ -52,7 +52,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-%s-envvars" (include "cronjobs.fullname" $) $job_name | include "com.klicktipp.slugify-string" }}
+  name: {{ include "com.klicktipp.slugify-string" (list (include "cronjobs.fullname" $) $job_name "envvars") }}
   labels:
     {{- include "cronjobs.labels" $ | nindent 4 }}
     {{- with $.Values.commonLabels }}

--- a/charts/cronjobs/templates/volumes.yaml
+++ b/charts/cronjobs/templates/volumes.yaml
@@ -1,6 +1,6 @@
 ---
 {{- range $job_name, $job := .Values.jobs }}
-{{- $JOB_NAME_SLUG := include "com.klicktipp.slugify-volume-name" $job_name }}
+{{- $JOB_NAME_SLUG := include "com.klicktipp.slugify-string" $job_name }}
 {{- if and $job (hasKey $job "storage") (hasKey $job.storage "efs") (hasKey $job.storage.efs "mounts") }}
 {{- range $efs_mount := $job.storage.efs.mounts }}
 {{- range $efs_ap := $efs_mount.access_points }}

--- a/charts/cronjobs/templates/volumes.yaml
+++ b/charts/cronjobs/templates/volumes.yaml
@@ -5,11 +5,7 @@
 {{- range $efs_mount := $job.storage.efs.mounts }}
 {{- range $efs_ap := $efs_mount.access_points }}
 {{- $EFS_AP_ID_TRIMMED := trimPrefix "fsap-" $efs_ap.id }}
-{{- $slugify  := ternary "com.klicktipp.slugify-volume-name-v2" "com.klicktipp.slugify-volume-name" (default false $.Values.slugifyVolumeNamesV2) -}}
-{{- $PV_NAME  := include $slugify (list $.Release.Namespace $.Release.Name $JOB_NAME_SLUG $EFS_AP_ID_TRIMMED) }}
-{{- $PVC_NAME := include $slugify (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
-{{- $PV_FULL  := join "-" (list $.Release.Namespace $.Release.Name $JOB_NAME_SLUG $EFS_AP_ID_TRIMMED) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
-{{- $PVC_FULL := join "-" (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
+{{- $slugify  := ternary "com.klicktipp.slugify-volume-name-v2" "com.klicktipp.slugify-volume-name" $.Values.slugifyVolumeNamesV2 -}}
 {{- $PV_NAME_SLUG  := include $slugify (list $.Release.Namespace $.Release.Name $JOB_NAME_SLUG $EFS_AP_ID_TRIMMED) }}
 {{- $PVC_NAME_SLUG := include $slugify (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
 {{- $PV_FULL_NAME  := join "-" (list $.Release.Namespace $.Release.Name $JOB_NAME_SLUG $EFS_AP_ID_TRIMMED) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}

--- a/charts/cronjobs/templates/volumes.yaml
+++ b/charts/cronjobs/templates/volumes.yaml
@@ -5,11 +5,12 @@
 {{- range $efs_mount := $job.storage.efs.mounts }}
 {{- range $efs_ap := $efs_mount.access_points }}
 {{- $EFS_AP_ID_TRIMMED := trimPrefix "fsap-" $efs_ap.id }}
-{{- $slugify  := ternary "com.klicktipp.slugify-volume-name-v2" "com.klicktipp.slugify-volume-name" $.Values.slugifyVolumeNamesV2 -}}
+{{- $slugify  := ternary "com.klicktipp.slugify-volume-name-v2" "com.klicktipp.slugify-volume-name" $.Values.slugifyVolumeNamesV2 }}
 {{- $PV_NAME_SLUG  := include $slugify (list $.Release.Namespace $.Release.Name $JOB_NAME_SLUG $EFS_AP_ID_TRIMMED) }}
 {{- $PVC_NAME_SLUG := include $slugify (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
-{{- $PV_FULL_NAME  := join "-" (list $.Release.Namespace $.Release.Name $JOB_NAME_SLUG $EFS_AP_ID_TRIMMED) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
-{{- $PVC_FULL_NAME := join "-" (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
+{{- $PV_FULL_NAME  := join "-" (list $.Release.Namespace $.Release.Name $JOB_NAME_SLUG $EFS_AP_ID_TRIMMED) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" }}
+{{- $PVC_FULL_NAME := join "-" (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" }}
+
 ---
 apiVersion: v1
 kind: PersistentVolume

--- a/charts/cronjobs/templates/volumes.yaml
+++ b/charts/cronjobs/templates/volumes.yaml
@@ -1,4 +1,3 @@
----
 {{- range $job_name, $job := .Values.jobs }}
 {{- $JOB_NAME_SLUG := include "com.klicktipp.slugify-string" $job_name }}
 {{- if and $job (hasKey $job "storage") (hasKey $job.storage "efs") (hasKey $job.storage.efs "mounts") }}

--- a/charts/cronjobs/templates/volumes.yaml
+++ b/charts/cronjobs/templates/volumes.yaml
@@ -10,11 +10,15 @@
 {{- $PVC_NAME := include $slugify (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
 {{- $PV_FULL  := join "-" (list $.Release.Namespace $.Release.Name $JOB_NAME_SLUG $EFS_AP_ID_TRIMMED) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
 {{- $PVC_FULL := join "-" (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
+{{- $PV_NAME_SLUG  := include $slugify (list $.Release.Namespace $.Release.Name $JOB_NAME_SLUG $EFS_AP_ID_TRIMMED) }}
+{{- $PVC_NAME_SLUG := include $slugify (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) }}
+{{- $PV_FULL_NAME  := join "-" (list $.Release.Namespace $.Release.Name $JOB_NAME_SLUG $EFS_AP_ID_TRIMMED) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
+{{- $PVC_FULL_NAME := join "-" (list $.Release.Name $JOB_NAME_SLUG (coalesce $efs_ap.name $efs_ap.path) $EFS_AP_ID_TRIMMED) | lower | replace "." "-" | replace "/" "-" | replace "_" "-" | replace "--" "-" | replace " " "-" | trimPrefix "-" | trimSuffix "-" -}}
 ---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ $PV_NAME }}
+  name: {{ $PV_NAME_SLUG }}
   labels:
     storage.ktsys.cloud/efs_fs_id: {{ $efs_mount.fs_id | quote }}
     storage.ktsys.cloud/efs_ap_id: {{ $efs_ap.id | quote }}
@@ -46,7 +50,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ $PVC_NAME }}
+  name: {{ $PVC_NAME_SLUG }}
   labels:
     storage.ktsys.cloud/efs_fs_id: {{ $efs_mount.fs_id | quote }}
     storage.ktsys.cloud/efs_ap_id: {{ $efs_ap.id | quote }}
@@ -66,7 +70,7 @@ spec:
   accessModes:
     - ReadWriteMany
   storageClassName: {{ $job.storage.efs.storageClass }}
-  volumeName: {{ $PV_NAME }}
+  volumeName: {{ $PV_NAME_SLUG }}
   resources:
     requests:
       storage: 5Gi  # Any number will do, we are just required to specify a storage capacity

--- a/charts/cronjobs/templates/volumes.yaml
+++ b/charts/cronjobs/templates/volumes.yaml
@@ -27,7 +27,7 @@ metadata:
     storage.ktsys.cloud/efs_name: {{ $efs_mount.fs_name | quote }}
     storage.ktsys.cloud/efs_ap_id: {{ $efs_ap.id | quote }}
     storage.ktsys.cloud/efs_path: {{ $efs_ap.path | quote }}
-    storage.ktsys.cloud/volume-name-full: {{ $PV_FULL | quote }}
+    storage.ktsys.cloud/volume-name-full: {{ $PV_FULL_NAME | quote }}
     {{- with $.commonAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -59,7 +59,7 @@ metadata:
     storage.ktsys.cloud/efs_name: {{ $efs_mount.fs_name | quote }}
     storage.ktsys.cloud/efs_ap_id: {{ $efs_ap.id | quote }}
     storage.ktsys.cloud/efs_path: {{ $efs_ap.path | quote }}
-    storage.ktsys.cloud/volume-name-full: {{ $PVC_FULL | quote }}
+    storage.ktsys.cloud/volume-name-full: {{ $PVC_FULL_NAME | quote }}
     {{- with $.commonAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/cronjobs/tests/volume_name_test.yaml
+++ b/charts/cronjobs/tests/volume_name_test.yaml
@@ -1,0 +1,46 @@
+suite: cronjobs-volume-name-tests
+release:
+  name: cronjobs
+  namespace: very-long-namespace-name-that-triggers-truncation
+templates:
+  - templates/cronjob.yaml
+  - templates/volumes.yaml
+
+tests:
+  - it: should keep legacy EFS volume names by default
+    values:
+      - ../ci/efs-volume-names.yaml
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts[0].name
+          value: cronjobs-a-very-long-cronjob-name-that-can-co-0e702cdce44153d31
+        template: templates/cronjob.yaml
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          value: cronjobs-a-very-long-cronjob-name-that-can-co-0e702cdce44153d31
+        template: templates/cronjob.yaml
+      - equal:
+          path: metadata.name
+          value: cronjobs-a-very-long-cronjob-name-that-can-co-0e702cdce44153d31
+        template: templates/volumes.yaml
+        documentIndex: 1
+
+  - it: should use hash-based EFS volume names when V2 is enabled
+    values:
+      - ../ci/efs-volume-names.yaml
+    set:
+      slugifyVolumeNamesV2: true
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts[0].name
+          value: cronjobs-5503b47f-0e702cdce44153d31
+        template: templates/cronjob.yaml
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          value: cronjobs-5503b47f-0e702cdce44153d31
+        template: templates/cronjob.yaml
+      - equal:
+          path: metadata.name
+          value: cronjobs-5503b47f-0e702cdce44153d31
+        template: templates/volumes.yaml
+        documentIndex: 1

--- a/charts/cronjobs/tests/volume_name_test.yaml
+++ b/charts/cronjobs/tests/volume_name_test.yaml
@@ -7,21 +7,21 @@ templates:
   - templates/volumes.yaml
 
 tests:
-  - it: should keep legacy EFS volume names by default
+  - it: should keep cronjobs 1.7.0 EFS volume names by default
     values:
       - ../ci/efs-volume-names.yaml
     asserts:
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts[0].name
-          value: cronjobs-a-very-long-cronjob-name-that-can-co-0e702cdce44153d31
+          value: cronjobs-a-very-long-cronjob-name-that-can-collide-very-long-pa
         template: templates/cronjob.yaml
       - equal:
           path: spec.jobTemplate.spec.template.spec.volumes[0].persistentVolumeClaim.claimName
-          value: cronjobs-a-very-long-cronjob-name-that-can-co-0e702cdce44153d31
+          value: cronjobs-a-very-long-cronjob-name-that-can-collide-very-long-pa
         template: templates/cronjob.yaml
       - equal:
           path: metadata.name
-          value: cronjobs-a-very-long-cronjob-name-that-can-co-0e702cdce44153d31
+          value: cronjobs-a-very-long-cronjob-name-that-can-collide-very-long-pa
         template: templates/volumes.yaml
         documentIndex: 1
 


### PR DESCRIPTION
This MR makes cronjobs volume naming safer and more predictable.

## What changed

* Adds `klicktipp-common` as a dependency for the cronjobs chart.
* Uses `com.klicktipp.slugify-string` for normal Kubernetes names.
* Keeps volume-specific naming separate for EFS PV/PVC names.
* Adds `slugifyVolumeNamesV2` tests to verify:
  * default behavior keeps legacy EFS volume names
  * `slugifyVolumeNamesV2: true` uses the new collision-free names
* Adds an EFS volume naming test values file.
* Updates cronjobs README with the new chart dependency.

## Why 

Cronjob PV/PVC names must not change just because the chart is upgraded. They should only change when `slugifyVolumeNamesV2: true` is explicitly enabled.

## Validation

* helm unittest charts/cronjobs
* helm lint charts/cronjobs -f charts/cronjobs/ci/efs-volume-names.yaml
* scripts/check-readme-consistency.sh charts/cronjobs