### PR TITLE
ci(docs-quality): auto-commit regenerated chart READMEs on PRs

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -8,15 +8,42 @@ on:
       - ".github/workflows/docs-quality.yml"
   workflow_dispatch:
 
+concurrency:
+  group: docs-quality-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   docs-quality:
     runs-on: ubuntu-latest
 
     steps:
+      # Only minted for same-repo pull requests once the app credentials exist.
+      # Without it the job keeps its original behaviour: verify, never auto-fix.
+      - name: Generate app token
+        id: app-token
+        if: >-
+          github.event_name == 'pull_request'
+          && vars.HELM_DOCS_BOT_APP_ID != ''
+          && github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.HELM_DOCS_BOT_APP_ID }}
+          private-key: ${{ secrets.HELM_DOCS_BOT_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          # Check out the PR head branch itself (not the detached merge commit)
+          # so regenerated READMEs can be pushed back. Fork PRs and
+          # workflow_dispatch fall back to the default checkout.
+          ref: >-
+            ${{ (github.event.pull_request.head.repo.full_name == github.repository
+            && github.event.pull_request.head.ref) || '' }}
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -73,6 +100,41 @@ jobs:
         run: |
           set -euo pipefail
           scripts/check-values-docs.sh ${{ steps.changed.outputs.values_files }}
+
+      - name: Regenerate chart READMEs
+        id: regen
+        if: steps.changed.outputs.has_charts == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts/generate-chart-readmes.sh
+
+          if git diff --quiet -- 'charts/*/README.md'; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+            git --no-pager diff --stat -- 'charts/*/README.md'
+          fi
+
+      # Pushing here re-triggers this workflow on the new head commit, so the
+      # PR ends up with a green check instead of a stale failing one. The rerun
+      # finds no drift, pushes nothing, and the loop stops.
+      - name: Commit regenerated READMEs
+        if: steps.regen.outputs.drift == 'true' && steps.app-token.outputs.token != ''
+        shell: bash
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          user_id="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
+
+          git add -- 'charts/*/README.md'
+          git commit -m "docs(charts): regenerate chart READMEs"
+          git push
 
       - name: Verify README consistency with values
         if: steps.changed.outputs.has_charts == 'true'

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -22,8 +22,11 @@ jobs:
     steps:
       # Only minted for same-repo pull requests once the app credentials exist.
       # Without it the job keeps its original behaviour: verify, never auto-fix.
+      # continue-on-error keeps a missing, misconfigured or expired credential
+      # from failing every chart pull request: it degrades to verify-only.
       - name: Generate app token
         id: app-token
+        continue-on-error: true
         if: >-
           github.event_name == 'pull_request'
           && vars.HELM_DOCS_BOT_APP_ID != ''

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -29,11 +29,11 @@ jobs:
         continue-on-error: true
         if: >-
           github.event_name == 'pull_request'
-          && vars.HELM_DOCS_BOT_APP_ID != ''
+          && vars.HELM_DOCS_BOT_CLIENT_ID != ''
           && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ vars.HELM_DOCS_BOT_APP_ID }}
+          client-id: ${{ vars.HELM_DOCS_BOT_CLIENT_ID }}
           private-key: ${{ secrets.HELM_DOCS_BOT_PRIVATE_KEY }}
 
       - name: Checkout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ This script ensures that the README of every changed chart stays in sync with th
 
 Do not hand-edit generated README sections when the content is derived from chart metadata or values. Regenerate or validate them through the repository scripts instead.
 
+On pull requests the `Helm Docs Quality` workflow regenerates the READMEs of the changed charts and, if they had drifted, commits the result back to the branch. Pull the branch before continuing to work on it. This is a safety net for automated dependency bumps, not a replacement for running the script yourself.
+
 ## Values documentation
 
 Whenever you change `values.yaml`, keep the Helm Docs comments (`# -- ...`) in sync and run `scripts/check-values-docs.sh` for the affected values file.


### PR DESCRIPTION
## Why

Renovate bumps `Chart.yaml` but never regenerates the helm-docs README, whose version badges are derived from that metadata. Every chart dependency PR therefore fails `docs-quality` and needs a manual follow-up commit.

This is not hypothetical: #175 failed exactly this way, and the drift had already been sitting on `main` since #172 merged without regenerating — the README was two bumps behind at 0.4.8 / 5.4.3 while `Chart.yaml` said 0.4.9 / 5.4.4.

## What

`docs-quality` now regenerates the changed charts' READMEs and, when they had drifted, commits the result back to the PR branch.

Extending the existing workflow rather than adding a parallel one keeps a single helm-docs install and puts the fix where the check already lives.

The push re-triggers this workflow on the new head commit, so the PR ends with a green check instead of a stale failing one. The rerun finds no drift, pushes nothing, and the loop terminates.

## Why a GitHub App token

Commits made with the default `GITHUB_TOKEN` deliberately do not trigger new workflow runs, which would leave the new head SHA with no checks at all — and Renovate's automerge waits on branch status.

## Fail-safe by design

The token is minted only for same-repo pull requests, and only when `vars.HELM_DOCS_BOT_CLIENT_ID` is set. The step is `continue-on-error`, so a missing, misconfigured or expired credential leaves the token output empty, skips the commit step, and restores exactly today's verify-only behaviour. Fork PRs and `workflow_dispatch` likewise never push.

This path is already proven: the first run on this branch had a misconfigured credential, the token step failed, and the job stayed green in verify-only mode instead of blocking the PR.

The Client ID lives in a repository *variable* rather than a secret because the `secrets` context is not available in step-level `if:` conditions, so the feature flag has to read from `vars`.

## Required configuration

| Kind | Name | Value |
|---|---|---|
| Variable | `HELM_DOCS_BOT_CLIENT_ID` | the app's **Client ID** (`Iv23...`), shown on the app settings page |
| Secret | `HELM_DOCS_BOT_PRIVATE_KEY` | full `.pem` contents |

App needs **Contents: Read and write** on this repository and nothing else. `client-id` replaces the deprecated `app-id` input.

## Validation

`yamllint` (repo `.yamllint`), `actionlint` and `shellcheck` are clean. The single `SC2129` finding actionlint reports is pre-existing in the untouched "Determine charts to check" step, confirmed by diffing against the baseline.

Note that this PR changes no charts, so `Determine charts to check` finds nothing and the regeneration steps skip. The auto-commit path needs a chart-touching PR to exercise end to end.

---

Produced by agent `github-updater` in workbench `update`.