### PR TITLE
DO NOT MERGE: verify docs-quality README auto-fix

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -8,15 +8,42 @@ on:
       - ".github/workflows/docs-quality.yml"
   workflow_dispatch:
 
+concurrency:
+  group: docs-quality-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   docs-quality:
     runs-on: ubuntu-latest
 
     steps:
+      # Only minted for same-repo pull requests once the app credentials exist.
+      # Without it the job keeps its original behaviour: verify, never auto-fix.
+      - name: Generate app token
+        id: app-token
+        if: >-
+          github.event_name == 'pull_request'
+          && vars.HELM_DOCS_BOT_APP_ID != ''
+          && github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.HELM_DOCS_BOT_APP_ID }}
+          private-key: ${{ secrets.HELM_DOCS_BOT_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          # Check out the PR head branch itself (not the detached merge commit)
+          # so regenerated READMEs can be pushed back. Fork PRs and
+          # workflow_dispatch fall back to the default checkout.
+          ref: >-
+            ${{ (github.event.pull_request.head.repo.full_name == github.repository
+            && github.event.pull_request.head.ref) || '' }}
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -73,6 +100,41 @@ jobs:
         run: |
           set -euo pipefail
           scripts/check-values-docs.sh ${{ steps.changed.outputs.values_files }}
+
+      - name: Regenerate chart READMEs
+        id: regen
+        if: steps.changed.outputs.has_charts == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts/generate-chart-readmes.sh
+
+          if git diff --quiet -- 'charts/*/README.md'; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+            git --no-pager diff --stat -- 'charts/*/README.md'
+          fi
+
+      # Pushing here re-triggers this workflow on the new head commit, so the
+      # PR ends up with a green check instead of a stale failing one. The rerun
+      # finds no drift, pushes nothing, and the loop stops.
+      - name: Commit regenerated READMEs
+        if: steps.regen.outputs.drift == 'true' && steps.app-token.outputs.token != ''
+        shell: bash
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          user_id="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
+
+          git add -- 'charts/*/README.md'
+          git commit -m "docs(charts): regenerate chart READMEs"
+          git push
 
       - name: Verify README consistency with values
         if: steps.changed.outputs.has_charts == 'true'

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -22,8 +22,11 @@ jobs:
     steps:
       # Only minted for same-repo pull requests once the app credentials exist.
       # Without it the job keeps its original behaviour: verify, never auto-fix.
+      # continue-on-error keeps a missing, misconfigured or expired credential
+      # from failing every chart pull request: it degrades to verify-only.
       - name: Generate app token
         id: app-token
+        continue-on-error: true
         if: >-
           github.event_name == 'pull_request'
           && vars.HELM_DOCS_BOT_APP_ID != ''

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -29,11 +29,11 @@ jobs:
         continue-on-error: true
         if: >-
           github.event_name == 'pull_request'
-          && vars.HELM_DOCS_BOT_APP_ID != ''
+          && vars.HELM_DOCS_BOT_CLIENT_ID != ''
           && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ vars.HELM_DOCS_BOT_APP_ID }}
+          client-id: ${{ vars.HELM_DOCS_BOT_CLIENT_ID }}
           private-key: ${{ secrets.HELM_DOCS_BOT_PRIVATE_KEY }}
 
       - name: Checkout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ This script ensures that the README of every changed chart stays in sync with th
 
 Do not hand-edit generated README sections when the content is derived from chart metadata or values. Regenerate or validate them through the repository scripts instead.
 
+On pull requests the `Helm Docs Quality` workflow regenerates the READMEs of the changed charts and, if they had drifted, commits the result back to the branch. Pull the branch before continuing to work on it. This is a safety net for automated dependency bumps, not a replacement for running the script yourself.
+
 ## Values documentation
 
 Whenever you change `values.yaml`, keep the Helm Docs comments (`# -- ...`) in sync and run `scripts/check-values-docs.sh` for the affected values file.

--- a/charts/powerdns-recursor/README.md
+++ b/charts/powerdns-recursor/README.md
@@ -1,6 +1,6 @@
 # powerdns-recursor
 
-![Version: 0.4.10](https://img.shields.io/badge/Version-0.4.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.4.5](https://img.shields.io/badge/AppVersion-5.4.5-informational?style=flat-square)
+![Version: 0.0.0-drift](https://img.shields.io/badge/Version-0.0.0--drift-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.4.5](https://img.shields.io/badge/AppVersion-5.4.5-informational?style=flat-square)
 
 Helm chart for deploying PowerDNS Recursor on Kubernetes
 

--- a/charts/powerdns-recursor/README.md
+++ b/charts/powerdns-recursor/README.md
@@ -1,6 +1,6 @@
 # powerdns-recursor
 
-![Version: 0.0.0-drift](https://img.shields.io/badge/Version-0.0.0--drift-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.4.5](https://img.shields.io/badge/AppVersion-5.4.5-informational?style=flat-square)
+![Version: 0.4.10](https://img.shields.io/badge/Version-0.4.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 5.4.5](https://img.shields.io/badge/AppVersion-5.4.5-informational?style=flat-square)
 
 Helm chart for deploying PowerDNS Recursor on Kubernetes
 


### PR DESCRIPTION
Throwaway PR verifying the auto-commit path added in #176.

The powerdns-recursor README badge was deliberately set to a bogus version. If the workflow behaves as intended, the bot commits a regenerated README, the rerun finds no drift, and no further commits appear.

Will be closed and the branch deleted once observed. Produced by agent `github-updater` in workbench `update`.