### PR TITLE
rspamd: Add Contour ingress and cert-manager support

### DIFF
--- a/charts/rspamd/Chart.yaml
+++ b/charts/rspamd/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: rspamd
 description: A Helm chart for deploying Rspamd on Kubernetes
 type: application
-version: 1.4.1
+version: 1.5.0
 # renovate: datasource=github-releases depName=rspamd/rspamd
 appVersion: 4.1.4
 keywords:

--- a/charts/rspamd/README.md
+++ b/charts/rspamd/README.md
@@ -1,6 +1,6 @@
 # rspamd
 
-![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.4](https://img.shields.io/badge/AppVersion-4.1.4-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.4](https://img.shields.io/badge/AppVersion-4.1.4-informational?style=flat-square)
 
 A Helm chart for deploying Rspamd on Kubernetes
 
@@ -14,6 +14,42 @@ A Helm chart for deploying Rspamd on Kubernetes
 
 * <https://github.com/rspamd/rspamd>
 * <https://rspamd.com>
+
+## Ingress controllers
+
+NGINX remains the default controller and continues to render the existing Kubernetes Ingress resources, including regex paths and rewrite annotations:
+
+```yaml
+ingress:
+  enabled: true
+  controller: nginx
+  className: nginx
+  singlePodPaths:
+    enabled: true
+```
+
+Set `controller: contour` to render one Contour `HTTPProxy` per configured host. Main paths come from `ingress.hosts[].paths`; tenant and per-pod prefixes use native Contour prefix rewriting. NGINX-specific annotations are omitted from each HTTPProxy.
+
+```yaml
+ingress:
+  enabled: true
+  controller: contour
+  className: contour-internal
+  singlePodPaths:
+    enabled: true
+  certManager:
+    enabled: true
+    issuerRef:
+      group: cert-manager.io
+      kind: ClusterIssuer
+      name: zerossl-prod
+  tls:
+    - secretName: rspamd.example.com-tls
+      hosts:
+        - rspamd.example.com
+```
+
+Contour does not provide the Ingress shim lifecycle used by cert-manager annotations on an Ingress. Before migrating an existing NGINX installation, ensure every TLS Secret is managed by an explicit `Certificate` (either enable `ingress.certManager` or provide one separately) before removing the old Ingress-owned Certificate.
 
 ## Values
 
@@ -65,14 +101,21 @@ A Helm chart for deploying Rspamd on Kubernetes
 | metrics.interval | string | `"60s"` | Scrape interval. |
 | metrics.scrapeTimeout | string | `""` | Optional scrape timeout. |
 | metrics.path | string | `"/metrics"` | Metrics path on the worker port. |
-| ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"chart-example.local","paths":[{"backend":{"serviceName":"","servicePort":11333},"path":"/","pathType":"Prefix"}]}],"singlePodPaths":{"enabled":true},"tls":[]}` | Ingress configuration. |
+| ingress | object | `{"annotations":{},"certManager":{"enabled":false,"issuerRef":{"group":"cert-manager.io","kind":"ClusterIssuer","name":""}},"className":"","controller":"nginx","enabled":false,"hosts":[{"host":"chart-example.local","paths":[{"backend":{"serviceName":"","servicePort":11333},"path":"/","pathType":"Prefix"}]}],"singlePodPaths":{"enabled":true},"tls":[]}` | Ingress configuration. |
 | ingress.enabled | bool | `false` | Enable ingress resources. |
-| ingress.className | string | `""` | ingressClassName value. |
-| ingress.annotations | object | `{}` | Ingress annotations. |
+| ingress.controller | string | `"nginx"` | Ingress controller implementation. Supported values are `nginx` and `contour`. |
+| ingress.className | string | `""` | ingressClassName value used by Ingress or HTTPProxy. |
+| ingress.annotations | object | `{}` | Annotations added to Ingress resources. Contour HTTPProxy resources omit NGINX-specific annotations. |
 | ingress.hosts | list | `[{"host":"chart-example.local","paths":[{"backend":{"serviceName":"","servicePort":11333},"path":"/","pathType":"Prefix"}]}]` | Ingress host/path rules. |
 | ingress.hosts[0].paths[0].backend.serviceName | string | `""` | Service name for this ingress path. If empty, defaults to chart Service. |
 | ingress.hosts[0].paths[0].backend.servicePort | int | `11333` | Service port for this ingress path. If empty, defaults to services.worker. |
 | ingress.tls | list | `[]` | TLS sections. |
+| ingress.certManager | object | `{"enabled":false,"issuerRef":{"group":"cert-manager.io","kind":"ClusterIssuer","name":""}}` | Optional explicit cert-manager Certificate management for Contour TLS. |
+| ingress.certManager.enabled | bool | `false` | Create cert-manager Certificate resources in Contour mode. |
+| ingress.certManager.issuerRef | object | `{"group":"cert-manager.io","kind":"ClusterIssuer","name":""}` | cert-manager issuer reference used by generated Certificates. |
+| ingress.certManager.issuerRef.group | string | `"cert-manager.io"` | API group of the cert-manager issuer. |
+| ingress.certManager.issuerRef.kind | string | `"ClusterIssuer"` | Issuer resource kind. |
+| ingress.certManager.issuerRef.name | string | `""` | Issuer resource name. Required when Certificate creation is enabled with TLS. |
 | ingress.singlePodPaths | object | `{"enabled":true}` | Extra ingress exposing per-pod endpoints for neighbour calls. |
 | ingress.singlePodPaths.enabled | bool | `true` | Enable dedicated per-pod ingress rules. |
 | resources | object | `{}` | Container resource requests and limits. |

--- a/charts/rspamd/README.md.gotmpl
+++ b/charts/rspamd/README.md.gotmpl
@@ -10,6 +10,42 @@
 {{ template "chart.maintainersSection" . }}
 {{ template "chart.sourcesSection" . }}
 
+## Ingress controllers
+
+NGINX remains the default controller and continues to render the existing Kubernetes Ingress resources, including regex paths and rewrite annotations:
+
+```yaml
+ingress:
+  enabled: true
+  controller: nginx
+  className: nginx
+  singlePodPaths:
+    enabled: true
+```
+
+Set `controller: contour` to render one Contour `HTTPProxy` per configured host. Main paths come from `ingress.hosts[].paths`; tenant and per-pod prefixes use native Contour prefix rewriting. NGINX-specific annotations are omitted from each HTTPProxy.
+
+```yaml
+ingress:
+  enabled: true
+  controller: contour
+  className: contour-internal
+  singlePodPaths:
+    enabled: true
+  certManager:
+    enabled: true
+    issuerRef:
+      group: cert-manager.io
+      kind: ClusterIssuer
+      name: zerossl-prod
+  tls:
+    - secretName: rspamd.example.com-tls
+      hosts:
+        - rspamd.example.com
+```
+
+Contour does not provide the Ingress shim lifecycle used by cert-manager annotations on an Ingress. Before migrating an existing NGINX installation, ensure every TLS Secret is managed by an explicit `Certificate` (either enable `ingress.certManager` or provide one separately) before removing the old Ingress-owned Certificate.
+
 {{ template "chart.valuesSection" . }}
 
 <!-- BEGIN AUTO EXAMPLES -->

--- a/charts/rspamd/templates/_helpers.tpl
+++ b/charts/rspamd/templates/_helpers.tpl
@@ -129,6 +129,12 @@ podAntiAffinity:
 Validate value combinations that would otherwise render broken manifests.
 */}}
 {{- define "rspamd.validateValues" }}
+{{- if and .Values.ingress.enabled (not (has .Values.ingress.controller (list "nginx" "contour"))) }}
+{{- fail (printf "rspamd: ingress.controller must be one of nginx or contour when ingress.enabled=true (got %q)" .Values.ingress.controller) }}
+{{- end }}
+{{- if and .Values.ingress.enabled (eq .Values.ingress.controller "contour") .Values.ingress.certManager.enabled .Values.ingress.tls (empty .Values.ingress.certManager.issuerRef.name) }}
+{{- fail "rspamd: ingress.certManager.issuerRef.name is required when Contour cert-manager certificate management and TLS are enabled" }}
+{{- end }}
 {{- if and .Values.multiTenancy (empty .Values.config) }}
 {{- fail "rspamd: multiTenancy=true requires at least one tenant entry in values.config" }}
 {{- end }}

--- a/charts/rspamd/templates/certificate.yaml
+++ b/charts/rspamd/templates/certificate.yaml
@@ -1,0 +1,24 @@
+{{- include "rspamd.validateValues" . }}
+{{- if and .Values.ingress.enabled (eq .Values.ingress.controller "contour") .Values.ingress.certManager.enabled .Values.ingress.tls }}
+{{- $root := . }}
+{{- $fullName := include "rspamd.fullname" . }}
+{{- range $index, $tls := .Values.ingress.tls }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ printf "%s-tls-%d" ($fullName | trunc 52 | trimSuffix "-") $index }}
+  labels:
+    {{- include "rspamd.labels" $root | nindent 4 }}
+spec:
+  secretName: {{ $tls.secretName | quote }}
+  dnsNames:
+    {{- range $tls.hosts }}
+    - {{ . | quote }}
+    {{- end }}
+  issuerRef:
+    group: {{ $root.Values.ingress.certManager.issuerRef.group | quote }}
+    kind: {{ $root.Values.ingress.certManager.issuerRef.kind | quote }}
+    name: {{ $root.Values.ingress.certManager.issuerRef.name | quote }}
+{{- end }}
+{{- end }}

--- a/charts/rspamd/templates/httpproxy.yaml
+++ b/charts/rspamd/templates/httpproxy.yaml
@@ -1,0 +1,96 @@
+{{- include "rspamd.validateValues" . }}
+{{- if and .Values.ingress.enabled (eq .Values.ingress.controller "contour") }}
+{{- $root := . }}
+{{- $fullName := include "rspamd.fullname" . }}
+{{- $hostCount := len .Values.ingress.hosts }}
+{{- $annotations := omit .Values.ingress.annotations
+      "nginx.ingress.kubernetes.io/use-regex"
+      "nginx.ingress.kubernetes.io/rewrite-target"
+      "nginx.ingress.kubernetes.io/backend-protocol"
+      "nginx.ingress.kubernetes.io/client-body-buffer-size"
+      "nginx.ingress.kubernetes.io/force-ssl-redirect" }}
+{{- range $_, $hostConfig := .Values.ingress.hosts }}
+{{- $host := $hostConfig.host | default $root.Values.global.baseURL }}
+{{- $tlsSecret := "" }}
+{{- range $tls := $root.Values.ingress.tls }}
+{{- if and (empty $tlsSecret) (has $host $tls.hosts) }}
+{{- $tlsSecret = $tls.secretName }}
+{{- end }}
+{{- end }}
+{{- $proxyName := $fullName }}
+{{- if gt $hostCount 1 }}
+{{- $hostHash := sha256sum $host | trunc 8 }}
+{{- $proxyName = printf "%s-%s" ($fullName | trunc 54 | trimSuffix "-") $hostHash }}
+{{- end }}
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: {{ $proxyName }}
+  labels:
+    {{- include "rspamd.labels" $root | nindent 4 }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $root.Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  virtualhost:
+    fqdn: {{ $host | quote }}
+    {{- with $tlsSecret }}
+    tls:
+      secretName: {{ . | quote }}
+    {{- end }}
+  routes:
+    {{- range $pathConfig := $hostConfig.paths }}
+    {{- $backend := ($pathConfig.backend | default dict) }}
+    {{- $serviceName := (get $backend "serviceName" | default (get $backend "service") | default $fullName) }}
+    {{- $servicePort := (get $backend "servicePort" | default (get $backend "port") | default $root.Values.services.worker) }}
+    - conditions:
+        - prefix: {{ $pathConfig.path | quote }}
+      services:
+        - name: {{ $serviceName | quote }}
+          port: {{ $servicePort }}
+    {{- end }}
+    {{- if $root.Values.multiTenancy }}
+    {{- range $tenant, $_ := $root.Values.config }}
+    - conditions:
+        - prefix: {{ printf "/%s/" $tenant | quote }}
+      pathRewritePolicy:
+        replacePrefix:
+          - prefix: {{ printf "/%s/" $tenant | quote }}
+            replacement: /
+      services:
+        - name: {{ $fullName }}-{{ $tenant }}
+          port: {{ $root.Values.services.worker }}
+    {{- if $root.Values.ingress.singlePodPaths.enabled }}
+    {{- range $index := until (int $root.Values.replicaCount) }}
+    - conditions:
+        - prefix: {{ printf "/rspamd-%s-%d/" $tenant $index | quote }}
+      pathRewritePolicy:
+        replacePrefix:
+          - prefix: {{ printf "/rspamd-%s-%d/" $tenant $index | quote }}
+            replacement: /
+      services:
+        - name: {{ $fullName }}-{{ $tenant }}-{{ $index }}
+          port: {{ $root.Values.services.controller }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- else if $root.Values.ingress.singlePodPaths.enabled }}
+    {{- range $index := until (int $root.Values.replicaCount) }}
+    - conditions:
+        - prefix: {{ printf "/rspamd-%d/" $index | quote }}
+      pathRewritePolicy:
+        replacePrefix:
+          - prefix: {{ printf "/rspamd-%d/" $index | quote }}
+            replacement: /
+      services:
+        - name: {{ $fullName }}-{{ $index }}
+          port: {{ $root.Values.services.controller }}
+    {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/rspamd/templates/ingress.yaml
+++ b/charts/rspamd/templates/ingress.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.ingress.enabled }}
+{{- include "rspamd.validateValues" . }}
+{{- if and .Values.ingress.enabled (eq .Values.ingress.controller "nginx") }}
 {{- $fullName := include "rspamd.fullname" . }}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}

--- a/charts/rspamd/tests/ingress_controllers_test.yaml
+++ b/charts/rspamd/tests/ingress_controllers_test.yaml
@@ -1,0 +1,274 @@
+suite: rspamd-ingress-controller-tests
+templates:
+  - templates/ingress.yaml
+  - templates/httpproxy.yaml
+  - templates/certificate.yaml
+
+tests:
+  - it: renders no exposure resources when ingress is disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/ingress.yaml
+      - hasDocuments:
+          count: 0
+        template: templates/httpproxy.yaml
+      - hasDocuments:
+          count: 0
+        template: templates/certificate.yaml
+
+  - it: preserves NGINX ingress regex and rewrite behavior
+    set:
+      ingress.enabled: true
+      ingress.controller: nginx
+      ingress.className: nginx
+      ingress.hosts:
+        - host: rspamd.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+              backend:
+                servicePort: 11334
+      ingress.singlePodPaths.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 2
+        template: templates/ingress.yaml
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/use-regex"]
+          value: "true"
+        template: templates/ingress.yaml
+        documentIndex: 1
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/rewrite-target"]
+          value: /$2
+        template: templates/ingress.yaml
+        documentIndex: 1
+      - hasDocuments:
+          count: 0
+        template: templates/httpproxy.yaml
+
+  - it: renders Contour main routes without per-pod routes
+    set:
+      ingress.enabled: true
+      ingress.controller: contour
+      ingress.className: contour-internal
+      ingress.hosts:
+        - host: rspamd.example.com
+          paths:
+            - path: /checkv2
+              backend:
+                servicePort: 11333
+            - path: /
+              backend:
+                servicePort: 11334
+      ingress.singlePodPaths.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/ingress.yaml
+      - hasDocuments:
+          count: 1
+        template: templates/httpproxy.yaml
+      - equal:
+          path: spec.ingressClassName
+          value: contour-internal
+        template: templates/httpproxy.yaml
+      - equal:
+          path: spec.routes[0].conditions[0].prefix
+          value: /checkv2
+        template: templates/httpproxy.yaml
+      - equal:
+          path: spec.routes[0].services[0].port
+          value: 11333
+        template: templates/httpproxy.yaml
+      - equal:
+          path: spec.routes[1].conditions[0].prefix
+          value: /
+        template: templates/httpproxy.yaml
+      - equal:
+          path: spec.routes[1].services[0].port
+          value: 11334
+        template: templates/httpproxy.yaml
+      - lengthEqual:
+          path: spec.routes
+          count: 2
+        template: templates/httpproxy.yaml
+      - hasDocuments:
+          count: 0
+        template: templates/certificate.yaml
+
+  - it: renders one Contour HTTPProxy per configured host
+    set:
+      ingress.enabled: true
+      ingress.controller: contour
+      ingress.hosts:
+        - host: rspamd-a.example.com
+          paths:
+            - path: /
+        - host: rspamd-b.example.com
+          paths:
+            - path: /
+      ingress.singlePodPaths.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 2
+        template: templates/httpproxy.yaml
+      - equal:
+          path: spec.virtualhost.fqdn
+          value: rspamd-a.example.com
+        template: templates/httpproxy.yaml
+        documentIndex: 0
+      - equal:
+          path: spec.virtualhost.fqdn
+          value: rspamd-b.example.com
+        template: templates/httpproxy.yaml
+        documentIndex: 1
+
+  - it: renders tenant and per-pod Contour routes for every replica
+    set:
+      replicaCount: 2
+      multiTenancy: true
+      config:
+        in: {}
+        out: {}
+      ingress.enabled: true
+      ingress.controller: contour
+      ingress.hosts:
+        - host: rspamd.example.com
+          paths:
+            - path: /checkv2
+              backend:
+                servicePort: 11333
+            - path: /
+              backend:
+                servicePort: 11334
+      ingress.singlePodPaths.enabled: true
+    asserts:
+      - lengthEqual:
+          path: spec.routes
+          count: 8
+        template: templates/httpproxy.yaml
+      - equal:
+          path: spec.routes[2].pathRewritePolicy.replacePrefix[0].replacement
+          value: /
+        template: templates/httpproxy.yaml
+      - equal:
+          path: spec.routes[3].conditions[0].prefix
+          value: /rspamd-in-0/
+        template: templates/httpproxy.yaml
+      - equal:
+          path: spec.routes[3].services[0].name
+          value: RELEASE-NAME-rspamd-in-0
+        template: templates/httpproxy.yaml
+      - equal:
+          path: spec.routes[3].services[0].port
+          value: 11334
+        template: templates/httpproxy.yaml
+      - equal:
+          path: spec.routes[7].conditions[0].prefix
+          value: /rspamd-out-1/
+        template: templates/httpproxy.yaml
+
+  - it: follows a different replica count for Contour per-pod routes
+    set:
+      replicaCount: 3
+      ingress.enabled: true
+      ingress.controller: contour
+      ingress.hosts:
+        - host: rspamd.example.com
+          paths:
+            - path: /
+      ingress.singlePodPaths.enabled: true
+    asserts:
+      - lengthEqual:
+          path: spec.routes
+          count: 4
+        template: templates/httpproxy.yaml
+      - equal:
+          path: spec.routes[3].conditions[0].prefix
+          value: /rspamd-2/
+        template: templates/httpproxy.yaml
+
+  - it: filters NGINX annotations from HTTPProxy and keeps other annotations
+    set:
+      ingress.enabled: true
+      ingress.controller: contour
+      ingress.annotations:
+        example.com/owner: mail
+        nginx.ingress.kubernetes.io/use-regex: "true"
+        nginx.ingress.kubernetes.io/rewrite-target: /$2
+        nginx.ingress.kubernetes.io/backend-protocol: HTTP
+        nginx.ingress.kubernetes.io/client-body-buffer-size: 100K
+        nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    asserts:
+      - equal:
+          path: metadata.annotations["example.com/owner"]
+          value: mail
+        template: templates/httpproxy.yaml
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/use-regex"]
+        template: templates/httpproxy.yaml
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/rewrite-target"]
+        template: templates/httpproxy.yaml
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/backend-protocol"]
+        template: templates/httpproxy.yaml
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/client-body-buffer-size"]
+        template: templates/httpproxy.yaml
+      - notExists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/force-ssl-redirect"]
+        template: templates/httpproxy.yaml
+
+  - it: renders Contour TLS and an explicit cert-manager Certificate
+    set:
+      ingress.enabled: true
+      ingress.controller: contour
+      ingress.className: contour-internal
+      ingress.hosts:
+        - host: rspamd.example.com
+          paths:
+            - path: /
+      ingress.tls:
+        - secretName: rspamd-example-tls
+          hosts:
+            - rspamd.example.com
+            - rspamd-alt.example.com
+      ingress.certManager.enabled: true
+      ingress.certManager.issuerRef:
+        group: cert-manager.io
+        kind: ClusterIssuer
+        name: zerossl-prod
+    asserts:
+      - equal:
+          path: spec.virtualhost.tls.secretName
+          value: rspamd-example-tls
+        template: templates/httpproxy.yaml
+      - equal:
+          path: spec.secretName
+          value: rspamd-example-tls
+        template: templates/certificate.yaml
+      - equal:
+          path: spec.dnsNames
+          value:
+            - rspamd.example.com
+            - rspamd-alt.example.com
+        template: templates/certificate.yaml
+      - equal:
+          path: spec.issuerRef
+          value:
+            group: cert-manager.io
+            kind: ClusterIssuer
+            name: zerossl-prod
+        template: templates/certificate.yaml
+
+  - it: rejects an unsupported ingress controller
+    set:
+      ingress.enabled: true
+      ingress.controller: traefik
+    asserts:
+      - failedTemplate:
+          errorMessage: 'rspamd: ingress.controller must be one of nginx or contour when ingress.enabled=true (got "traefik")'
+        template: templates/ingress.yaml

--- a/charts/rspamd/values.yaml
+++ b/charts/rspamd/values.yaml
@@ -120,9 +120,11 @@ metrics:
 ingress:
   # -- Enable ingress resources.
   enabled: false
-  # -- ingressClassName value.
+  # -- Ingress controller implementation. Supported values are `nginx` and `contour`.
+  controller: nginx
+  # -- ingressClassName value used by Ingress or HTTPProxy.
   className: ""
-  # -- Ingress annotations.
+  # -- Annotations added to Ingress resources. Contour HTTPProxy resources omit NGINX-specific annotations.
   annotations: {}
   # -- Ingress host/path rules.
   hosts:
@@ -140,6 +142,18 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+  # -- Optional explicit cert-manager Certificate management for Contour TLS.
+  certManager:
+    # -- Create cert-manager Certificate resources in Contour mode.
+    enabled: false
+    # -- cert-manager issuer reference used by generated Certificates.
+    issuerRef:
+      # -- API group of the cert-manager issuer.
+      group: cert-manager.io
+      # -- Issuer resource kind.
+      kind: ClusterIssuer
+      # -- Issuer resource name. Required when Certificate creation is enabled with TLS.
+      name: ""
   # -- Extra ingress exposing per-pod endpoints for neighbour calls.
   singlePodPaths:
     # -- Enable dedicated per-pod ingress rules.


### PR DESCRIPTION
Introduce ingress.controller with nginx or contour modes Add HTTPProxy templates and optional cert-manager Certificates Filter NGINX-specific annotations for Contour resources Update values, README, and validation logic